### PR TITLE
fix(lid): align ECAPA classifier with SpeechBrain

### DIFF
--- a/mlx_audio/lid/models/ecapa_tdnn/ecapa_tdnn.py
+++ b/mlx_audio/lid/models/ecapa_tdnn/ecapa_tdnn.py
@@ -36,7 +36,7 @@ class DNNBlock(nn.Module):
         self.norm = nn.BatchNorm(out_dim)
 
     def __call__(self, x: mx.array) -> mx.array:
-        return nn.relu(self.norm(self.linear(x)))
+        return self.norm(nn.leaky_relu(self.linear(x), negative_slope=0.01))
 
 
 class DNN(nn.Module):
@@ -66,6 +66,7 @@ class EcapaClassifier(nn.Module):
 
     def __call__(self, x: mx.array) -> mx.array:
         out = mx.squeeze(x, axis=1)
+        out = nn.leaky_relu(out, negative_slope=0.01)
         out = self.norm(out)
         out = self.DNN(out)
         out = self.out(out)
@@ -121,9 +122,15 @@ class ECAPA_TDNN(nn.Module):
         Returns:
             Log-probabilities ``[batch, num_classes]``.
         """
-        embeddings = self.embedding_model(mel_features)
+        normalized_mel_features = self.sentence_mean_normalize(mel_features)
+        embeddings = self.embedding_model(normalized_mel_features)
         embeddings = mx.expand_dims(embeddings, axis=1)
         return self.classifier(embeddings)
+
+    @staticmethod
+    def sentence_mean_normalize(mel_features: mx.array) -> mx.array:
+        """Mirror SpeechBrain's sentence-level mean-only InputNormalization."""
+        return mel_features - mx.mean(mel_features, axis=1, keepdims=True)
 
     def predict(
         self,

--- a/mlx_audio/lid/tests/test_lid.py
+++ b/mlx_audio/lid/tests/test_lid.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
+import mlx.nn as nn
 import numpy as np
 
 
@@ -328,6 +329,36 @@ class TestEcapaTdnnModel(unittest.TestCase):
         mx.eval(probs)
         total = float(mx.sum(probs[0]).item())
         self.assertAlmostEqual(total, 1.0, places=3)
+
+    def test_sentence_mean_normalize_centers_each_mel_bin(self):
+        mel = mx.array([[[1.0, 3.0], [3.0, 5.0], [5.0, 7.0]]])
+        normalized = self.Model.sentence_mean_normalize(mel)
+        mean_per_bin = mx.mean(normalized, axis=1)
+        mx.eval(mean_per_bin)
+
+        self.assertAlmostEqual(float(mean_per_bin[0, 0].item()), 0.0, places=5)
+        self.assertAlmostEqual(float(mean_per_bin[0, 1].item()), 0.0, places=5)
+
+    def test_classifier_matches_speechbrain_order(self):
+        model = self.Model(self.config)
+        classifier = model.classifier
+        x = mx.random.normal((1, 1, self.config.embedding_dim))
+
+        expected = mx.squeeze(x, axis=1)
+        expected = nn.leaky_relu(expected, negative_slope=0.01)
+        expected = classifier.norm(expected)
+        expected = classifier.DNN.block_0.linear(expected)
+        expected = nn.leaky_relu(expected, negative_slope=0.01)
+        expected = classifier.DNN.block_0.norm(expected)
+        expected = classifier.out(expected)
+        expected = mx.log(mx.softmax(expected, axis=-1) + 1e-10)
+
+        actual = classifier(x)
+        mx.eval(expected, actual)
+
+        self.assertTrue(
+            mx.allclose(actual, expected, atol=1e-5, rtol=1e-5).item()
+        )
 
     def test_predict_returns_sorted(self):
         model = self.Model(self.config)

--- a/mlx_audio/lid/tests/test_lid.py
+++ b/mlx_audio/lid/tests/test_lid.py
@@ -341,6 +341,7 @@ class TestEcapaTdnnModel(unittest.TestCase):
 
     def test_classifier_matches_speechbrain_order(self):
         model = self.Model(self.config)
+        model.eval()
         classifier = model.classifier
         x = mx.random.normal((1, 1, self.config.embedding_dim))
 


### PR DESCRIPTION
## Summary
- align the ECAPA LID classifier order with SpeechBrain Xvector.Classifier
- switch classifier activations from ReLU to LeakyReLU where required
- add sentence-level mean normalization before the ECAPA backbone
- add targeted regression tests for classifier order and feature normalization

## Root cause
The converted MLX ECAPA backbone was already close to upstream, but the LID classifier was ported with a different layer order than SpeechBrain. That made the converted model predict different classes from the original upstream model even on the same embeddings.

## Verification
- `./.venv/bin/python -m unittest mlx_audio.lid.tests.test_lid.TestEcapaTdnnModel.test_sentence_mean_normalize_centers_each_mel_bin mlx_audio.lid.tests.test_lid.TestEcapaTdnnModel.test_classifier_matches_speechbrain_order`
- original SpeechBrain on `sample40-16k.wav`: `tl: Tagalog`
- this branch on the same file: `[("tl", 0.7876), ("en", 0.1324), ("ar", 0.0278), ("eo", 0.0076), ("nl", 0.0060)]`

## Notes
- upstream `speechbrain/speechbrain` currently matches `tl: Tagalog` on the same sample
- before this fix, the MLX port incorrectly produced `ar` as top-1 on that input