### PR TITLE
feat(omnivoice): real create_voice_clone_prompt() using HiggsAudioTokenizer

### DIFF
--- a/mlx_audio/tts/models/omnivoice/omnivoice.py
+++ b/mlx_audio/tts/models/omnivoice/omnivoice.py
@@ -94,6 +94,7 @@ class Model(nn.Module):
         num_steps: int = 32,
         guidance_scale: float = 2.0,
         temperature: float = 5.0,
+        tokenizer=None,
     ) -> GenerationResult:
         from .generation import iterative_unmask
 
@@ -116,8 +117,13 @@ class Model(nn.Module):
         )
         processing_time_seconds = time.time() - start_time
 
+        if tokenizer is not None:
+            audio = tokenizer.decode(tokens)  # [T*960] 1D for 2D tokens input
+        else:
+            audio = None
+
         return GenerationResult(
-            audio=None,
+            audio=audio,
             samples=0,
             sample_rate=self.config.sample_rate,
             segment_idx=0,

--- a/mlx_audio/tts/tests/test_omnivoice.py
+++ b/mlx_audio/tts/tests/test_omnivoice.py
@@ -505,5 +505,61 @@ class TestVoiceCloneUtils(unittest.TestCase):
         os.unlink(tmp_path)
 
 
+class TestOmniVoiceGenerateWithTokenizer(unittest.TestCase):
+    def _make_model(self):
+        from mlx_audio.tts.models.omnivoice.config import OmniVoiceConfig
+        from mlx_audio.tts.models.omnivoice.omnivoice import Model
+
+        cfg = OmniVoiceConfig.from_dict(
+            {
+                "model_type": "omnivoice",
+                "audio_vocab_size": 1025,
+                "audio_mask_id": 1024,
+                "num_audio_codebook": 8,
+                "sample_rate": 24000,
+                "llm_config": {
+                    "hidden_size": 64,
+                    "num_hidden_layers": 2,
+                    "num_attention_heads": 4,
+                    "num_key_value_heads": 2,
+                    "intermediate_size": 128,
+                    "vocab_size": 200,
+                    "head_dim": 16,
+                    "rms_norm_eps": 1e-6,
+                },
+            }
+        )
+        return Model(cfg)
+
+    def _make_tokenizer(self):
+        from mlx_audio.codec.models.higgs_audio.config import HiggsAudioConfig
+        from mlx_audio.codec.models.higgs_audio.higgs_audio import HiggsAudioTokenizer
+
+        return HiggsAudioTokenizer(HiggsAudioConfig())
+
+    def test_audio_is_none_without_tokenizer(self):
+        model = self._make_model()
+        input_ids = mx.zeros((5,), dtype=mx.int32)
+        result = model.generate(input_ids, duration_s=0.1, num_steps=2)
+        self.assertIsNone(result.audio)
+
+    def test_audio_is_array_with_tokenizer(self):
+        model = self._make_model()
+        tok = self._make_tokenizer()
+        input_ids = mx.zeros((5,), dtype=mx.int32)
+        result = model.generate(input_ids, duration_s=0.1, num_steps=2, tokenizer=tok)
+        self.assertIsNotNone(result.audio)
+        self.assertIsInstance(result.audio, mx.array)
+
+    def test_samples_count_with_tokenizer(self):
+        model = self._make_model()
+        tok = self._make_tokenizer()
+        input_ids = mx.zeros((5,), dtype=mx.int32)
+        result = model.generate(input_ids, duration_s=0.1, num_steps=2, tokenizer=tok)
+        # tokens is [T, 8]; decode returns [T*960] 1D
+        expected_samples = result.token_count * 960
+        self.assertEqual(result.audio.size, expected_samples)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Implements real audio loading, resampling to 24kHz, and encoding via `HiggsAudioTokenizer` in `create_voice_clone_prompt()`
- Returns empty prefix `[0, 8]` when `tokenizer=None` for backward compatibility
- Raises `FileNotFoundError` if the reference audio path does not exist
- Wires optional `tokenizer` parameter into `Model.generate()` so it returns a real waveform via `tokenizer.decode()`

## Test plan

- [x] `test_no_tokenizer_returns_empty` — verifies shape `(0, 8)` and `int32` dtype when no tokenizer is provided
- [x] `test_missing_file_raises` — verifies `FileNotFoundError` is raised for a nonexistent path
- [x] `test_with_tokenizer_returns_2d` — creates a real 2-second 24kHz WAV, encodes it, checks `ndim==2`, `shape[1]==8`, `dtype==int32`
- [x] `test_audio_is_none_without_tokenizer` — `generate()` without tokenizer returns `audio=None`
- [x] `test_audio_is_array_with_tokenizer` — `generate()` with tokenizer returns an `mx.array`
- [x] `test_samples_count_with_tokenizer` — decoded sample count matches `token_count * 960`
- [x] All 33 tests pass