### PR TITLE
ci: domain-filtered test execution via dynamic matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,84 @@ on:
       - main
 
 jobs:
-  # Style checks run once
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      shared: ${{ steps.compute.outputs.shared }}
+      domains: ${{ steps.compute.outputs.domains }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - id: filter
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            shared:
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'MANIFEST.in'
+              - 'pytest.ini'
+              - '.pre-commit-config.yaml'
+              - '.github/workflows/tests.yml'
+              - 'mlx_audio/utils.py'
+              - 'mlx_audio/dsp.py'
+              - 'mlx_audio/audio_io.py'
+              - 'mlx_audio/__init__.py'
+              - 'mlx_audio/tests/**'
+            stt:
+              - 'mlx_audio/stt/**'
+            tts:
+              - 'mlx_audio/tts/**'
+            sts:
+              - 'mlx_audio/sts/**'
+            codec:
+              - 'mlx_audio/codec/**'
+            vad:
+              - 'mlx_audio/vad/**'
+            lid:
+              - 'mlx_audio/lid/**'
+
+      - id: compute
+        env:
+          SHARED: ${{ steps.filter.outputs.shared_any_changed }}
+          STT: ${{ steps.filter.outputs.stt_any_changed }}
+          TTS: ${{ steps.filter.outputs.tts_any_changed }}
+          STS: ${{ steps.filter.outputs.sts_any_changed }}
+          CODEC: ${{ steps.filter.outputs.codec_any_changed }}
+          VAD: ${{ steps.filter.outputs.vad_any_changed }}
+          LID: ${{ steps.filter.outputs.lid_any_changed }}
+        run: |
+          set -e
+          if [ "$SHARED" = "true" ]; then
+            domains='["stt","tts","sts","codec","vad","lid"]'
+          else
+            domains='[]'
+            for d in stt tts sts codec vad lid; do
+              case "$d" in
+                stt)   val="$STT"   ;;
+                tts)   val="$TTS"   ;;
+                sts)   val="$STS"   ;;
+                codec) val="$CODEC" ;;
+                vad)   val="$VAD"   ;;
+                lid)   val="$LID"   ;;
+              esac
+              if [ "$val" = "true" ]; then
+                domains=$(echo "$domains" | jq -c ". + [\"$d\"]")
+              fi
+            done
+          fi
+          echo "shared=${SHARED:-false}" >> "$GITHUB_OUTPUT"
+          echo "domains=$domains" >> "$GITHUB_OUTPUT"
+          echo "Computed shared=${SHARED:-false} domains=$domains"
+
   style:
     runs-on: macos-14
+    needs: changes
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -27,10 +102,10 @@ jobs:
             exit 1
           fi
 
-  # Core tests (DSP, utils)
   core:
     runs-on: macos-14
-    needs: style
+    needs: [changes, style]
+    if: needs.changes.outputs.shared == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -48,12 +123,10 @@ jobs:
       - name: Run core tests
         run: pytest -s mlx_audio/tests/
 
-  # Modular installation tests - validates issue #287
-  # Only verifies imports work with minimal deps installed.
-  # Full tests run separately with all deps (test files import models that need extra deps).
   modular:
     runs-on: macos-14
-    needs: style
+    needs: [changes, style]
+    if: needs.changes.outputs.shared == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -77,27 +150,14 @@ jobs:
       - name: Verify ${{ matrix.extra }} imports
         run: python -c "${{ matrix.verify }}; print('${{ matrix.extra }} imports OK')"
 
-  # Full test suites - need all deps
   tests:
     runs-on: macos-14
-    needs: style
+    needs: [changes, style]
+    if: needs.changes.outputs.domains != '[]'
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: TTS
-            path: mlx_audio/tts/tests
-          - name: STT
-            path: mlx_audio/stt/tests
-          - name: STS
-            path: mlx_audio/sts/tests
-          - name: LID
-            path: mlx_audio/lid/tests
-          - name: Codec
-            path: mlx_audio/codec/tests
-          - name: VAD
-            path: mlx_audio/vad/tests
-
+        domain: ${{ fromJSON(needs.changes.outputs.domains) }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -107,5 +167,5 @@ jobs:
       - name: Install all deps
         run: pip install -e ".[all,dev]"
 
-      - name: Run ${{ matrix.name }} tests
-        run: pytest -s ${{ matrix.path }}/
+      - name: Run ${{ matrix.domain }} tests
+        run: pytest -s mlx_audio/${{ matrix.domain }}/tests/


### PR DESCRIPTION
# CI: domain-filtered test execution via dynamic matrix

Single signed commit, one file changed (`.github/workflows/tests.yml` +85/-25). Replaces the earlier draft of this PR with the simplest possible mechanism: one `tj-actions/changed-files@v45` invocation exposes `<domain>_any_changed` flags, a 15-line shell + `jq` step turns them into a JSON list of active domains, and the `tests` job consumes that list as a dynamic matrix (`strategy.matrix.domain: fromJSON(needs.changes.outputs.domains)`).

## Why dynamic matrix

The previous draft of this PR ran an in-step `should_run` shell gate on every matrix leg — TTS/STS/Codec/VAD/LID legs would still allocate a macos-14 runner, set up Python, and print `Skipped (X unaffected)` before exiting. Wall time per skipped leg: ~1m 28s (mostly `setup-python@v6` overhead). That's ~7min of paid macos-14 minutes wasted per PR, and the GitHub Actions UI showed every leg as a green checkmark with a duration — actively misleading.

Dynamic matrix fixes both:

- Skipped domains do not appear as jobs at all → no runner allocation.
- The UI accurately reflects what was tested. Reviewers can see at a glance which domain a PR touched.
- macos-14 minutes are billed at 10× linux, so this is real cost savings on every PR.

## Behaviour

| PR scope | `domains` output | `tests` legs | `core` / `modular` |
|---|---|---|---|
| Touches `pyproject.toml`, workflow file, `mlx_audio/utils.py`, etc. | `["stt","tts","sts","codec","vad","lid"]` | All 6 | Run |
| Touches only `mlx_audio/stt/**` | `["stt"]` | 1 leg (stt) | Skipped |
| Touches `stt` and `tts` | `["stt","tts"]` | 2 legs | Skipped |
| Touches only docs/README | `[]` | Job does not spawn | Skipped |

`core` and `modular` validate cross-package import contracts (lazy imports, modular `pip install -e ".[stt]"` etc.), so they remain gated on `shared`.

`style` (pre-commit) is unconditional.

## Implementation snippet

```yaml
changes:
  runs-on: ubuntu-latest
  outputs:
    shared:  ${{ steps.compute.outputs.shared }}
    domains: ${{ steps.compute.outputs.domains }}
  steps:
    - uses: actions/checkout@v6
      with: { fetch-depth: 2 }
    - id: filter
      uses: tj-actions/changed-files@v45
      with:
        files_yaml: |
          shared:
            - 'pyproject.toml'
            - '.github/workflows/tests.yml'
            - 'mlx_audio/utils.py'
            # ...
          stt: ['mlx_audio/stt/**']
          tts: ['mlx_audio/tts/**']
          # ... sts, codec, vad, lid
    - id: compute
      env:
        SHARED: ${{ steps.filter.outputs.shared_any_changed }}
        STT:    ${{ steps.filter.outputs.stt_any_changed }}
        # ... etc
      run: |
        if [ "$SHARED" = "true" ]; then
          domains='["stt","tts","sts","codec","vad","lid"]'
        else
          domains='[]'
          for d in stt tts sts codec vad lid; do
            case "$d" in
              stt) val="$STT";; tts) val="$TTS";; sts) val="$STS";;
              codec) val="$CODEC";; vad) val="$VAD";; lid) val="$LID";;
            esac
            [ "$val" = "true" ] && domains=$(echo "$domains" | jq -c ". + [\"$d\"]")
          done
        fi
        echo "shared=${SHARED:-false}" >> "$GITHUB_OUTPUT"
        echo "domains=$domains" >> "$GITHUB_OUTPUT"

tests:
  needs: [changes, style]
  if: needs.changes.outputs.domains != '[]'
  strategy:
    fail-fast: false
    matrix:
      domain: ${{ fromJSON(needs.changes.outputs.domains) }}
  steps:
    - uses: actions/checkout@v6
    - uses: actions/setup-python@v6
      with: { python-version: '3.10' }
    - run: pip install -e ".[all,dev]"
    - run: pytest -s mlx_audio/${{ matrix.domain }}/tests/
```

The bucket layout matches the existing directory structure (`stt`, `tts`, `sts`, `codec`, `vad`, `lid`), so no extra YAML mapping file or classification script is required. The compute step is the only added logic.

## What this does NOT do (out of scope, can be follow-up)

- Per-model gating inside `test_models.py` catch-alls. Touching one STT model still runs all STT tests; the win there is bigger but needs a class-name → model-name map. Easy to add later if profiling shows it's worth it.
- Per-extra modular gating. `core` and `modular` only run on shared changes today. If you want them to run on per-domain changes too, just relax the `if:` conditions.

## Tests

- `python -m yaml.safe_load` parses the workflow file cleanly.
- Local sanity test of the `compute` shell logic across all 6 input combinations (shared / single-domain / multi-domain / empty / shared-overrides) produces the expected JSON arrays.
- `pytest mlx_audio/stt/tests/test_models.py -k "Cohere or Parakeet"` still 14/14 (no Python code changes in this PR).

## Note on this PR's own CI run

Because the diff is `.github/workflows/tests.yml` itself (which is in the `shared` bucket), this PR triggers every domain leg plus `core` and `modular` — by design. Workflow infra change → run everything. The path-filter savings show up on subsequent PRs that touch only domain code.

## Files

```
.github/workflows/tests.yml   +85/-25
```

(One file. The `model-filters.yml` and `classify_changes.py` from the v1 draft are still deleted.)
