### PR TITLE
test(ci-narrow): verify path-filter narrows to STT only

### DIFF
--- a/mlx_audio/stt/models/cohere_asr/cohere_asr.py
+++ b/mlx_audio/stt/models/cohere_asr/cohere_asr.py
@@ -13,6 +13,8 @@ from .audio import CohereAudioFrontend
 from .config import DecoderInnerConfig, EncoderConfig, ModelConfig
 from .tokenizer import CohereAsrTokenizer
 
+# ci-narrow-test: stt-only diff to verify path-filter narrows matrix to ["stt"]
+
 NO_SPACE_LANGS = {"ja", "zh"}
 
 


### PR DESCRIPTION
Throwaway PR to verify the dynamic-matrix path-filter from PR #19 actually narrows the matrix.

Diff = 1 comment-line in mlx_audio/stt/models/cohere_asr/cohere_asr.py.

Expected CI:
- changes job logs 'Computed shared=false domains=["stt"]'
- only style + tests (stt) jobs spawn
- core, modular, tests (tts|sts|codec|vad|lid) DO NOT exist

Will be closed and branch deleted after verification.