### PR TITLE
feat(tts/zonos2): MoE block (MLP+EDA router, SwitchGLU experts)

### DIFF
--- a/mlx_audio/tts/models/zonos2/moe.py
+++ b/mlx_audio/tts/models/zonos2/moe.py
@@ -1,0 +1,224 @@
+"""ZONOS2 sparse-MoE block (MLX port).
+
+Mirrors the upstream ``zonos2.models.zonos2`` MoE stack:
+
+* ``Router``            -> ``Router`` + ``RouterMLP`` (EDA + balancing-bias top-k)
+* ``MoEFeedForward``    -> ``MoEFeedForward`` + ``FusedGroupedExperts``
+
+The fused ``w13`` (interleaved gate/up) -> split conversion lives in
+``convert.py``; here the experts already consume SEPARATE ``gate_proj`` /
+``up_proj`` / ``down_proj`` weights via :class:`mlx_lm.models.switch_layers.SwitchGLU`
+(``mx.gather_mm``).
+
+Reference: https://github.com/Zyphra/ZONOS2 -> python/zonos2/models/zonos2.py
+(``Router`` ~L523-626, ``RouterMLP`` ~L457-509, ``FusedGroupedExperts`` ~L334-454,
+``MoEFeedForward`` ~L629-671).
+
+Parity notes (matching the released checkpoint):
+* Router math runs in fp32 (``balancing_biases``, softmax, top-k selection).
+* ``norm_topk_prob`` is ``False`` upstream, so the top-2 layer (26) does NOT
+  renormalize the selected weights -- it keeps the raw softmax probabilities.
+* The balancing bias steers expert SELECTION only; the returned weights are the
+  ORIGINAL (un-biased) softmax probabilities of the chosen experts.
+* GELU is the exact (erf) form, matching ``torch.nn.functional.gelu`` default.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.bailing_moe import aggregate_expert_outputs
+from mlx_lm.models.switch_layers import SwitchGLU
+
+from mlx_audio.tts.models.zonos2.config import ZONOS2Config
+
+
+def split_sonic_w13(w13: mx.array) -> Tuple[mx.array, mx.array]:
+    """De-interleave a SonicMoE fused ``w13`` into ``(gate, up)``.
+
+    ``w13`` is rank-3 ``[experts, 2 * intermediate, hidden]`` with gate/up rows
+    interleaved (gate = even rows, up = odd rows). Mirrors upstream
+    ``_convert_sonic_w13_to_gate_up`` (which concatenates ``[gate, up]``); here we
+    return the two halves separately for ``SwitchGLU``'s split projections.
+
+    Used by ``convert.py`` -- kept here so the de-interleave convention has a
+    single source of truth.
+    """
+    if w13.ndim != 3:
+        raise ValueError(f"Expected SonicMoE w13 to be rank-3, got {w13.shape}")
+    if w13.shape[1] % 2 != 0:
+        raise ValueError(f"Expected even fused width in SonicMoE w13, got {w13.shape}")
+    gate = w13[:, 0::2, :]
+    up = w13[:, 1::2, :]
+    return gate, up
+
+
+class RouterMLP(nn.Module):
+    """Router MLP mirroring upstream ``nn.Sequential`` numeric naming.
+
+    Sequential structure (GELU at indices 1/3 are stateless):
+        0: Linear(router_dim, router_dim, bias=True)
+        1: GELU
+        2: Linear(router_dim, router_dim, bias=True)
+        3: GELU
+        4: Linear(router_dim, num_experts, bias=False)
+    """
+
+    def __init__(self, router_dim: int, num_experts: int):
+        super().__init__()
+        # Exact (erf) GELU to match torch.nn.functional.gelu's default; MLX's
+        # ``approx="precise"`` is the *tanh* approximation (~5e-4 error), so the
+        # default ``nn.GELU()`` is the parity-correct choice here.
+        self.layers = [
+            nn.Linear(router_dim, router_dim, bias=True),
+            nn.GELU(),
+            nn.Linear(router_dim, router_dim, bias=True),
+            nn.GELU(),
+            nn.Linear(router_dim, num_experts, bias=False),
+        ]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+class Router(nn.Module):
+    """MoE router with EDA blending + balancing-bias-aware top-k selection.
+
+    ``__call__(x) -> (indices[B, T, k], weights[B, T, k])`` where ``k`` is
+    ``config.num_experts_per_tok(layer_id)``.
+
+    Checkpoint keys (under ``...feed_forward.router.``):
+        down_proj.{weight,bias}          Linear(hidden -> router_dim)
+        rmsnorm_eda.weight               RMSNorm(router_dim)
+        router_mlp.{0,2,4}.weight, .{0,2}.bias   GELU MLP -> num_experts logits
+        balancing_biases [num_experts]   fp32, added before top-k
+        router_states_scale [router_dim] EDA layers only
+    """
+
+    def __init__(self, config: ZONOS2Config, layer_id: int):
+        super().__init__()
+        self.hidden_size = config.dim
+        self.router_dim = config.moe_router_dim
+        self.num_experts = config.moe_n_experts
+        self.top_k = config.num_experts_per_tok(layer_id)
+        # ``norm_topk_prob`` is False for the released checkpoint -> never renorm.
+        self.norm_topk_prob = False
+
+        self.down_proj = nn.Linear(self.hidden_size, self.router_dim, bias=True)
+        self.router_mlp = RouterMLP(self.router_dim, self.num_experts)
+        self.rmsnorm_eda = nn.RMSNorm(self.router_dim, eps=config.norm_eps)
+
+        # EDA is active for every MoE layer except the first MoE layer.
+        self.use_eda = layer_id != config.moe_start_from_layer
+        if self.use_eda:
+            self.router_states_scale = mx.ones((self.router_dim,))
+
+        # Balancing biases steer SELECTION only (fp32); legacy strategy adds them.
+        self.balancing_biases = mx.zeros((self.num_experts,), dtype=mx.float32)
+
+    def __call__(
+        self,
+        x: mx.array,
+        router_states: Optional[mx.array] = None,
+        *,
+        return_router_states: bool = False,
+    ):
+        """Route ``x`` to top-k experts.
+
+        Args:
+            x: ``[B, T, dim]`` hidden states.
+            router_states: ``[B, T, router_dim]`` from the previous MoE layer
+                (EDA chaining). When ``None`` the EDA blend is skipped, matching
+                upstream's ``if self.use_eda and router_states is not None``.
+            return_router_states: when True also return ``router_states_next``
+                (the pre-norm router hidden states) for the next layer's EDA.
+
+        Returns:
+            ``(indices[B, T, k], weights[B, T, k])`` or, with
+            ``return_router_states``, ``(indices, weights, router_states_next)``.
+        """
+        hidden = self.down_proj(x)
+
+        if self.use_eda and router_states is not None:
+            hidden = hidden + router_states * self.router_states_scale
+
+        # Saved BEFORE normalization for the next layer's EDA blend.
+        router_states_next = hidden
+
+        hidden = self.rmsnorm_eda(hidden)
+
+        # Router math is fp32 (parity with the checkpoint).
+        logits = self.router_mlp(hidden).astype(mx.float32)
+        expert_prob = mx.softmax(logits, axis=-1)
+
+        # Legacy balancing: bias added to scores used only for top-k selection.
+        routing_scores = expert_prob + self.balancing_biases
+
+        k = self.top_k
+        indices = mx.argpartition(routing_scores, kth=-k, axis=-1)[..., -k:]
+        # Order selected experts by descending routing score (stable downstream).
+        selected = mx.take_along_axis(routing_scores, indices, axis=-1)
+        order = mx.argsort(-selected, axis=-1)
+        indices = mx.take_along_axis(indices, order, axis=-1)
+
+        # Returned weights are the ORIGINAL (un-biased) probabilities.
+        weights = mx.take_along_axis(expert_prob, indices, axis=-1)
+        if k > 1 and self.norm_topk_prob:
+            weights = weights / (weights.sum(axis=-1, keepdims=True) + 1e-20)
+
+        if return_router_states:
+            return indices, weights, router_states_next
+        return indices, weights
+
+
+class MoEFeedForward(nn.Module):
+    """Sparse MoE feed-forward: route via :class:`Router`, run :class:`SwitchGLU`.
+
+    ``__call__(x) -> [B, T, dim]``. Experts use SEPARATE gate/up/down weights
+    (the fused ``w13`` split is done in ``convert.py``).
+    """
+
+    def __init__(self, config: ZONOS2Config, layer_id: int):
+        super().__init__()
+        self.router = Router(config, layer_id)
+        moe_inter = (
+            config.moe_intermediate_size
+            if config.moe_intermediate_size > 0
+            else config.intermediate_size
+        )
+        self.experts = SwitchGLU(
+            input_dims=config.dim,
+            hidden_dims=moe_inter,
+            num_experts=config.moe_n_experts,
+            bias=False,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        router_states: Optional[mx.array] = None,
+        *,
+        return_router_states: bool = False,
+    ):
+        """Apply the MoE block.
+
+        Args mirror :meth:`Router.__call__`; with ``return_router_states`` the
+        next-layer EDA states are returned alongside the output.
+        """
+        in_dtype = x.dtype
+        indices, weights, router_states_next = self.router(
+            x, router_states, return_router_states=True
+        )
+
+        expert_out = self.experts(x, indices)
+        out = aggregate_expert_outputs(
+            expert_out.astype(mx.float32), weights.astype(mx.float32)
+        ).astype(in_dtype)
+
+        if return_router_states:
+            return out, router_states_next
+        return out

--- a/mlx_audio/tts/models/zonos2/tests/test_moe.py
+++ b/mlx_audio/tts/models/zonos2/tests/test_moe.py
@@ -1,0 +1,166 @@
+"""Synthetic shape/behaviour tests for the ZONOS2 MoE block (no GPU/CUDA).
+
+Tiny config: dim=64, moe_n_experts=4, moe_router_dim=16, moe_start_from_layer=0.
+The MoE intermediate is overridden via ``ffn_dim_multiplier``/``multiple_of`` so
+the synthetic experts stay small.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+
+from mlx_audio.tts.models.zonos2.config import ZONOS2Config
+from mlx_audio.tts.models.zonos2.moe import (
+    MoEFeedForward,
+    Router,
+    RouterMLP,
+    split_sonic_w13,
+)
+
+
+def _realize(*arrays: mx.array) -> None:
+    """Force MLX lazy arrays to materialize (sidesteps eval() naming)."""
+    for arr in arrays:
+        np.asarray(arr)
+
+
+def _tiny_config(**overrides) -> ZONOS2Config:
+    base = dict(
+        n_layers=4,
+        dim=64,
+        head_dim=16,
+        n_kv_heads=2,
+        ffn_dim_multiplier=2.0,  # -> intermediate_size 128 (rounded to multiple_of)
+        multiple_of=32,
+        moe_n_experts=4,
+        moe_router_dim=16,
+        moe_router_topk=1,
+        moe_start_from_layer=0,
+        moe_end_from_layer=0,
+    )
+    base.update(overrides)
+    return ZONOS2Config(**base)
+
+
+def test_moe_feed_forward_preserves_shape():
+    config = _tiny_config()
+    moe = MoEFeedForward(config, layer_id=1)
+    x = mx.random.normal((1, 3, 64))
+    out = moe(x)
+    assert out.shape == (1, 3, 64)
+    assert out.dtype == x.dtype
+    _realize(out)
+
+
+def test_router_shapes_top1():
+    config = _tiny_config()
+    router = Router(config, layer_id=1)
+    k = config.num_experts_per_tok(1)
+    assert k == 1
+    x = mx.random.normal((1, 3, 64))
+    indices, weights = router(x)
+    assert indices.shape == (1, 3, k)
+    assert weights.shape == (1, 3, k)
+    # Selected expert ids are valid.
+    _realize(indices, weights)
+    assert int(indices.min()) >= 0
+    assert int(indices.max()) < config.moe_n_experts
+
+
+def test_router_top2_layer():
+    # special_topk_layers makes layer 2 select two experts.
+    config = _tiny_config(special_topk_layers={2: 2})
+    assert config.num_experts_per_tok(2) == 2
+    router = Router(config, layer_id=2)
+    x = mx.random.normal((1, 5, 64))
+    indices, weights = router(x)
+    assert indices.shape == (1, 5, 2)
+    assert weights.shape == (1, 5, 2)
+    # Each token's two selected experts are distinct.
+    pairs = np.asarray(indices)
+    for row in pairs[0]:
+        assert row[0] != row[1]
+
+
+def test_router_weights_are_unbiased_softmax_probs():
+    # Returned weights must be the original (un-biased) softmax probabilities,
+    # so each lies in (0, 1); with norm_topk_prob False they are NOT renormalized.
+    config = _tiny_config(special_topk_layers={2: 2})
+    router = Router(config, layer_id=2)
+    x = mx.random.normal((1, 4, 64))
+    _, weights = router(x)
+    w = np.asarray(weights)[0]
+    for row in w:
+        for p in row:
+            assert 0.0 < p < 1.0
+        # top-2 probabilities are NOT renormalized (no forced sum to 1).
+        assert float(sum(row)) < 1.0 + 1e-4
+
+
+def test_router_balancing_bias_steers_selection_only():
+    # A large bias on one expert should force its selection while the returned
+    # weight stays the original softmax prob (not the biased score).
+    config = _tiny_config()
+    router = Router(config, layer_id=1)
+    forced = 2
+    bias = [0.0] * config.moe_n_experts
+    bias[forced] = 100.0
+    router.balancing_biases = mx.array(bias, dtype=mx.float32)
+    x = mx.random.normal((1, 6, 64))
+    indices, weights = router(x)
+    idx = np.asarray(indices).reshape(-1)
+    wt = np.asarray(weights).reshape(-1)
+    assert all(int(i) == forced for i in idx)
+    # Weight is a plain softmax prob (< 1), not the +100 biased score.
+    assert all(0.0 < float(p) < 1.0 for p in wt)
+
+
+def test_eda_blend_changes_router_states():
+    # With EDA active (layer_id != moe_start_from_layer) passing router_states
+    # should alter the routing relative to no router_states.
+    config = _tiny_config()
+    router = Router(config, layer_id=1)
+    assert router.use_eda
+    x = mx.random.normal((1, 3, 64))
+    rs = mx.random.normal((1, 3, config.moe_router_dim)) * 10.0
+    _, _, next_a = router(x, return_router_states=True)
+    _, _, next_b = router(x, rs, return_router_states=True)
+    assert next_a.shape == (1, 3, config.moe_router_dim)
+    # router_states_next differs once EDA blending is applied.
+    assert not bool(mx.allclose(next_a, next_b))
+
+
+def test_first_moe_layer_has_no_eda():
+    config = _tiny_config()
+    router = Router(config, layer_id=config.moe_start_from_layer)
+    assert not router.use_eda
+    assert "router_states_scale" not in dict(router.parameters())
+
+
+def test_routermlp_structure_and_shape():
+    mlp = RouterMLP(router_dim=16, num_experts=4)
+    x = mx.random.normal((2, 16))
+    out = mlp(x)
+    assert out.shape == (2, 4)
+    # Mirror upstream nn.Sequential numbering: linears at 0/2/4, GELU at 1/3.
+    assert mlp.layers[1].__class__.__name__ == "GELU"
+    assert mlp.layers[3].__class__.__name__ == "GELU"
+
+
+def test_split_sonic_w13_deinterleaves():
+    experts, inter, hidden = 2, 3, 5
+    # Build w13 so even rows are "gate" and odd rows are "up".
+    gate_src = mx.arange(experts * inter * hidden).reshape(experts, inter, hidden)
+    up_src = gate_src + 1000
+    # Interleave: row 0=gate0, row 1=up0, row 2=gate1, ...
+    rows = []
+    for i in range(inter):
+        rows.append(gate_src[:, i : i + 1, :])
+        rows.append(up_src[:, i : i + 1, :])
+    w13 = mx.concatenate(rows, axis=1)
+    gate, up = split_sonic_w13(w13)
+    assert gate.shape == (experts, inter, hidden)
+    assert up.shape == (experts, inter, hidden)
+    assert bool(mx.array_equal(gate, gate_src))
+    assert bool(mx.array_equal(up, up_src))


### PR DESCRIPTION
Ports the ZONOS2 sparse-MoE feed-forward block to MLX (`mlx_audio/tts/models/zonos2/moe.py`), mirroring upstream `zonos2.models.zonos2` exactly.

## What
- **`Router`** — `down_proj` (Linear hidden->128, bias) -> optional EDA blend (`+ router_states * router_states_scale`, skipped when no states, matching upstream guard) -> `rmsnorm_eda` -> GELU MLP -> 16 expert logits. fp32 softmax; `balancing_biases` (fp32) added to scores for top-k **selection only** (`mx.argpartition`); returned weights are the **original un-biased** softmax probs gathered at the selected experts. `norm_topk_prob=False` (released ckpt) so the top-2 layer (26) is **not** renormalized.
- **`MoEFeedForward`** — routes via `Router`, runs experts through `mlx_lm` `SwitchGLU` (`mx.gather_mm`) with separate `gate_proj`/`up_proj`/`down_proj`, aggregates via `aggregate_expert_outputs`.
- **`split_sonic_w13`** helper (gate = even rows, up = odd rows) — used by `convert.py`.

## Parity notes
- Router math is fp32 throughout (biases, softmax, top-k).
- **GELU is exact (erf)** to match `torch.nn.functional.gelu` default — MLX's `approx="precise"` is the *tanh* approximation (~5e-4 error), so plain `nn.GELU()` is the parity-correct choice (caught + fixed in self-review).
- Expert weight shapes verified: gate/up `[E, moe_inter, hidden]`, down `[E, hidden, moe_inter]` — matches what `convert.py` produces.

## Tests
`tests/test_moe.py` (synthetic, no GPU) — 9 passing: shape preservation [1,3,64]->[1,3,64], top-1/top-2 routing k, un-biased weight gather, balancing-bias steers selection only, EDA blending changes router states, first-MoE-layer has no EDA, RouterMLP structure, w13 de-interleave.

Scope: only `moe.py` + `tests/test_moe.py`. Integration (Phase D) and `convert.py` weight remap owned by the coordinator.