### PR TITLE
feat(tts/zonos2): speaker LDA + conditioning buckets

### DIFF
--- a/mlx_audio/tts/models/zonos2/speaker.py
+++ b/mlx_audio/tts/models/zonos2/speaker.py
@@ -1,0 +1,186 @@
+"""Speaker conditioning for the ZONOS2 MLX port.
+
+Two pieces:
+
+* :class:`SpeakerLDA` -- the affine LDA projection applied to the raw 2048-D
+  speaker embedding, mirroring upstream ``models/speaker_lda.py``
+  (``SpeakerLDAProjection``). It is a plain ``F.linear`` (weight + bias, **no**
+  mean-centering), so it maps directly to an ``mlx.nn.Linear``. Checkpoint keys:
+  ``speaker_lda_projection.{weight,bias}``.
+
+* :func:`speaking_rate_bucket` / :func:`quality_bucket` -- map a continuous
+  value to the discrete conditioning-bucket index, parsing the boundary strings
+  stored on :class:`~mlx_audio.tts.models.zonos2.config.ZONOS2Config`
+  (``speaking_rate_buckets`` like ``"8-11"`` / ``"40+"``; ``quality_buckets``
+  like ``"-50--45.5"`` / ``"60+"`` / exact ``"0"``). The boundary semantics
+  mirror upstream ``server/api_server.py`` (``_speaking_rate_bucket_for_rate``,
+  ``_quality_bucket_for_value`` and their ``*_BUCKET_RE`` parsers).
+
+Reference: https://github.com/Zyphra/ZONOS2 -> python/zonos2/models/speaker_lda.py
+and python/zonos2/server/api_server.py (bucket parsing / value->index).
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_audio.tts.models.zonos2.config import ZONOS2Config
+
+# --- bucket boundary regexes (mirror upstream server/api_server.py) ---
+# Speaking-rate buckets only ever use non-negative values, e.g. "8-11" / "40+".
+_SPEAKING_RATE_CLOSED_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*-\s*(\d+(?:\.\d+)?)\s*$")
+_SPEAKING_RATE_OPEN_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*\+\s*$")
+
+# Quality buckets may carry signed numbers, so the separating "-" can sit next
+# to a leading "-" of the upper bound, e.g. "-50--45.5" -> low=-50, high=-45.5.
+_QUALITY_NUMBER = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)"
+_QUALITY_EXACT_RE = re.compile(rf"^\s*({_QUALITY_NUMBER})\s*$")
+_QUALITY_CLOSED_RE = re.compile(
+    rf"^\s*({_QUALITY_NUMBER})\s*-\s*({_QUALITY_NUMBER})\s*$"
+)
+_QUALITY_OPEN_RE = re.compile(rf"^\s*({_QUALITY_NUMBER})\s*\+\s*$")
+
+
+class SpeakerLDA(nn.Module):
+    """Affine LDA projection over raw speaker embeddings.
+
+    Mirrors upstream ``SpeakerLDAProjection`` (``F.linear(x, weight, bias)``):
+    a plain affine map with bias and **no** mean-centering. MLX ``nn.Linear``
+    stores ``weight`` as ``[output_dim, input_dim]`` and computes
+    ``x @ weight.T + bias`` -- identical to the upstream ``F.linear`` layout, so
+    the checkpoint tensors ``speaker_lda_projection.{weight,bias}`` load directly
+    onto ``self.proj.{weight,bias}``.
+    """
+
+    def __init__(self, config: ZONOS2Config) -> None:
+        super().__init__()
+        input_dim = config.speaker_embedding_dim
+        output_dim = config.speaker_lda_dim
+        if output_dim is None:
+            raise ValueError("config.speaker_lda_dim must be set for SpeakerLDA.")
+        self.proj = nn.Linear(input_dim, output_dim, bias=True)
+
+    def __call__(self, emb_2048: mx.array) -> mx.array:
+        return self.proj(emb_2048)
+
+
+def _parse_speaking_rate_bucket(spec: str) -> Tuple[float, Optional[float]]:
+    """Parse one speaking-rate bucket string into ``(low, high)``.
+
+    ``high`` is ``None`` for an open-ended bucket like ``"40+"``.
+    """
+    closed = _SPEAKING_RATE_CLOSED_RE.match(str(spec))
+    if closed is not None:
+        return float(closed.group(1)), float(closed.group(2))
+    open_ended = _SPEAKING_RATE_OPEN_RE.match(str(spec))
+    if open_ended is not None:
+        return float(open_ended.group(1)), None
+    raise ValueError(
+        f"Invalid speaking-rate bucket {spec!r}; expected ranges like '0-3' or '60+'."
+    )
+
+
+def _parse_quality_bucket(spec: str) -> Tuple[str, float, Optional[float]]:
+    """Parse one quality bucket string into ``(kind, low, high)``.
+
+    ``kind`` is ``"exact"`` (single value, ``high`` is ``None``) or ``"range"``
+    (``high`` is ``None`` only for an open-ended ``"X+"`` bucket).
+    """
+    value = str(spec)
+    exact = _QUALITY_EXACT_RE.match(value)
+    if exact is not None:
+        return "exact", float(exact.group(1)), None
+    closed = _QUALITY_CLOSED_RE.match(value)
+    if closed is not None:
+        return "range", float(closed.group(1)), float(closed.group(2))
+    open_ended = _QUALITY_OPEN_RE.match(value)
+    if open_ended is not None:
+        return "range", float(open_ended.group(1)), None
+    raise ValueError(
+        f"Invalid quality bucket {spec!r}; expected exact values like '0', "
+        "ranges like '-30--25', or open-ended ranges like '22050+'."
+    )
+
+
+def speaking_rate_bucket(value: float, config: ZONOS2Config) -> int:
+    """Return the speaking-rate bucket index for ``value``.
+
+    Mirrors upstream ``_speaking_rate_bucket_for_rate`` (with ranges present):
+    iterate the contiguous ``config.speaking_rate_buckets`` ranges in order and
+    return the first whose upper bound is open (``"X+"``) or strictly greater
+    than ``value`` (the boundary ``value == high`` falls into the *next*
+    bucket). Falls back to the last bucket.
+    """
+    rate = float(value)
+    if rate <= 0:
+        raise ValueError("speaking_rate must be positive.")
+
+    ranges = [
+        _parse_speaking_rate_bucket(spec) for spec in config.speaking_rate_buckets
+    ]
+    if not ranges:
+        raise ValueError("config.speaking_rate_buckets is empty.")
+
+    for idx, (_, high) in enumerate(ranges):
+        if high is None or (
+            rate < high and not math.isclose(rate, high, rel_tol=1e-12, abs_tol=1e-9)
+        ):
+            return idx
+    return len(ranges) - 1
+
+
+def quality_bucket(feature: str, value: float, config: ZONOS2Config) -> int:
+    """Return the quality bucket index for ``feature`` at ``value``.
+
+    Mirrors upstream ``_quality_bucket_for_value``:
+
+    * exact buckets win first when ``value`` matches (``math.isclose``);
+    * among range buckets, an open-ended ``"X+"`` matches ``value >= low``, the
+      last range matches inclusive ``low <= value <= high``, and every other
+      range matches half-open ``low <= value < high``;
+    * out-of-range values clamp to the first/last range bucket.
+    """
+    buckets = (config.quality_buckets or {}).get(feature)
+    if not buckets:
+        raise ValueError(
+            f"config.quality_buckets has no entry for feature {feature!r}."
+        )
+
+    val = float(value)
+    if not math.isfinite(val):
+        raise ValueError("quality value must be finite.")
+
+    specs = [_parse_quality_bucket(spec) for spec in buckets]
+
+    for idx, (kind, low, _high) in enumerate(specs):
+        if kind == "exact" and math.isclose(val, low, rel_tol=1e-12, abs_tol=1e-9):
+            return idx
+
+    range_indexes: List[int] = [
+        idx for idx, (kind, _, _) in enumerate(specs) if kind == "range"
+    ]
+    if not range_indexes:
+        raise ValueError(
+            f"config.quality_buckets[{feature!r}] has no range buckets to place {val}."
+        )
+
+    for idx in range_indexes:
+        _, low, high = specs[idx]
+        if high is None:
+            if val >= low:
+                return idx
+        elif idx == range_indexes[-1]:
+            if low <= val <= high:
+                return idx
+        elif low <= val < high:
+            return idx
+
+    _, first_low, _ = specs[range_indexes[0]]
+    if val < first_low:
+        return range_indexes[0]
+    return range_indexes[-1]

--- a/mlx_audio/tts/models/zonos2/tests/test_speaker.py
+++ b/mlx_audio/tts/models/zonos2/tests/test_speaker.py
@@ -1,0 +1,123 @@
+"""Synthetic unit tests for the ZONOS2 speaker module.
+
+No GPU/CUDA fixtures: ``SpeakerLDA`` is checked for shape only, and the bucket
+helpers are checked against hand-derived boundary cases that mirror upstream
+``server/api_server.py`` semantics.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from mlx_audio.tts.models.zonos2.config import ZONOS2Config
+from mlx_audio.tts.models.zonos2.speaker import (
+    SpeakerLDA,
+    quality_bucket,
+    speaking_rate_bucket,
+)
+
+
+def _config() -> ZONOS2Config:
+    return ZONOS2Config(
+        speaker_embedding_dim=2048,
+        speaker_lda_dim=1024,
+        # Contiguous, non-negative, ends open-ended (mirrors upstream rules).
+        speaking_rate_buckets=("0-8", "8-11", "11-40", "40+"),
+        quality_features=("lufs", "snr"),
+        quality_buckets={
+            # Fully-negative ranges + a closed positive range + open-ended.
+            "lufs": ("-1000--50", "-50--45.5", "-45.5--40", "-40+"),
+            # Includes an exact-value bucket and a fully-negative range.
+            "snr": ("-1000-0", "0", "0-10", "10+"),
+        },
+    )
+
+
+# --- SpeakerLDA --------------------------------------------------------------
+
+
+def test_speaker_lda_shape():
+    config = _config()
+    lda = SpeakerLDA(config)
+    out = lda(mx.zeros((2, 2048)))
+    assert out.shape == (2, 1024)
+
+
+def test_speaker_lda_is_affine_with_bias():
+    config = _config()
+    lda = SpeakerLDA(config)
+    # Weight stored as [out, in]; bias present (mirrors F.linear, no centering).
+    assert lda.proj.weight.shape == (1024, 2048)
+    assert "bias" in lda.proj
+    assert lda.proj.bias.shape == (1024,)
+
+
+# --- speaking_rate_bucket ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (0.5, 0),  # small positive -> bucket 0 ("0-8")
+        (8.0, 1),  # boundary value falls into the NEXT bucket ("8-11")
+        (9.0, 1),  # inside "8-11"
+        (11.0, 2),  # boundary -> "11-40"
+        (39.9, 2),  # inside "11-40"
+        (40.0, 3),  # boundary -> open-ended "40+"
+        (100.0, 3),  # large -> last "40+"
+    ],
+)
+def test_speaking_rate_bucket(value, expected):
+    assert speaking_rate_bucket(value, _config()) == expected
+
+
+def test_speaking_rate_bucket_rejects_non_positive():
+    with pytest.raises(ValueError):
+        speaking_rate_bucket(0.0, _config())
+
+
+# --- quality_bucket ----------------------------------------------------------
+
+
+def test_quality_bucket_negative_range():
+    # -47 lands in the fully-negative range "-50--45.5" (index 1).
+    assert quality_bucket("lufs", -47.0, _config()) == 1
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (-500.0, 0),  # "-1000--50"
+        (-50.0, 1),  # boundary -> half-open next "-50--45.5"
+        (-45.5, 2),  # boundary -> "-45.5--40"
+        (-40.0, 3),  # open-ended "-40+"
+        (1000.0, 3),  # large -> open-ended bucket
+    ],
+)
+def test_quality_bucket_lufs_boundaries(value, expected):
+    assert quality_bucket("lufs", value, _config()) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (-5.0, 0),  # fully-negative range "-1000-0"
+        (0.0, 1),  # exact bucket "0" wins over the range edges
+        (5.0, 2),  # "0-10"
+        (10.0, 3),  # open-ended "10+"
+        (50.0, 3),  # large -> "10+"
+    ],
+)
+def test_quality_bucket_snr_with_exact(value, expected):
+    assert quality_bucket("snr", value, _config()) == expected
+
+
+def test_quality_bucket_clamps_below_first_range():
+    # Below the first range's lower bound -> clamp to first range bucket.
+    assert quality_bucket("lufs", -5000.0, _config()) == 0
+
+
+def test_quality_bucket_unknown_feature_raises():
+    with pytest.raises(ValueError):
+        quality_bucket("does_not_exist", 0.0, _config())


### PR DESCRIPTION
Implements `mlx_audio/tts/models/zonos2/speaker.py` per CONTRACT.md.

## What
- **`SpeakerLDA(config)`** — affine LDA projection `speaker_embedding_dim`(2048) → `speaker_lda_dim`(1024). Mirrors upstream `models/speaker_lda.py` `SpeakerLDAProjection` (`F.linear` with weight `[out,in]` + bias, **no mean-centering**) via `nn.Linear(in, out, bias=True)`. Loads `speaker_lda_projection.{weight,bias}`.
- **`speaking_rate_bucket(value, config)`** and **`quality_bucket(feature, value, config)`** — parse the config bucket boundary strings (`"8-11"`, `"40+"`, fully-negative `"-50--45.5"`, exact `"0"`) and return the bucket index for a value.

## Parity
Boundary semantics mirror upstream `server/api_server.py` exactly:
- speaking-rate: iterate ranges, first `high is None` or `value < high` (with `math.isclose(rel_tol=1e-12, abs_tol=1e-9)` so `value == high` → next bucket); fallback last.
- quality: exact-wins first; open-ended `"X+"` matches `value >= low`; last range inclusive `low <= v <= high`; others half-open `low <= v < high`; clamp to first/last range otherwise.

## Tests
Synthetic pytest (`tests/test_speaker.py`), 23 cases — `[2,2048]→[2,1024]` shape, affine weight layout + bias, rate boundaries (`8→1`, `40→3`, `100→3`), `quality_bucket("lufs", -47)→1`, open-ended bucket, exact-wins, negative-range parsing, clamp. **23 passed.**

Code-review (extra-high recall): all candidate findings refuted against the authoritative upstream source — the implementation is a faithful mirror (including the exact `math.isclose` tolerances).