### PR TITLE
feat(tts/zonos2): UTF-8 byte tokenizer + optional NeMo TN

### DIFF
--- a/mlx_audio/tts/models/zonos2/tests/test_tokenizer.py
+++ b/mlx_audio/tts/models/zonos2/tests/test_tokenizer.py
@@ -1,0 +1,116 @@
+"""Synthetic tests for the ZONOS2 UTF-8 byte tokenizer.
+
+No GPU / weights: pure byte round-trip + special-token layout + the
+NeMo-normalization fallback path.
+"""
+
+from __future__ import annotations
+
+import builtins
+
+import pytest
+
+from mlx_audio.tts.models.zonos2.tokenizer import (
+    BYTE_ID_END,
+    BYTE_ID_START,
+    SPECIAL_TOKEN_IDS,
+    TEXT_VOCAB,
+    ZONOS2Tokenizer,
+)
+
+
+@pytest.fixture()
+def tokenizer() -> ZONOS2Tokenizer:
+    return ZONOS2Tokenizer()
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "Hello, world!",
+        "The quick brown fox jumps over the lazy dog.",
+        "ASCII 0123456789 ~!@#$%^&*()",
+        "\t newline\n and tabs ",
+        "你好，世界",  # CJK: "你好，世界"
+        "café naïve résumé",  # accented Latin
+        "emoji \U0001f600\U0001f680\U0001f44d mixed こんにちは",  # emoji + Japanese
+    ],
+)
+def test_byte_round_trip(tokenizer: ZONOS2Tokenizer, text: str) -> None:
+    assert tokenizer.decode(tokenizer.encode(text)) == text
+
+
+def test_encode_wraps_with_bos_eos(tokenizer: ZONOS2Tokenizer) -> None:
+    ids = tokenizer.encode("A")
+    assert ids[0] == tokenizer.bos_id
+    assert ids[-1] == tokenizer.eos_id
+    # "A" == byte 65 -> id 65 + 192 == 257
+    assert ids == [tokenizer.bos_id, 65 + BYTE_ID_START, tokenizer.eos_id]
+
+
+def test_byte_ids_are_offset_by_legacy_symbol_block(
+    tokenizer: ZONOS2Tokenizer,
+) -> None:
+    # Every UTF-8 byte maps into the contiguous [192, 448) block.
+    for byte in range(256):
+        ch = bytes([byte])
+        ids = [tok for tok in tokenizer.encode(ch.decode("latin-1"))]
+        body = ids[1:-1]  # strip BOS / EOS
+        for tok in body:
+            assert BYTE_ID_START <= tok < BYTE_ID_END
+
+
+def test_special_ids_in_range_and_distinct_from_byte_ids() -> None:
+    # All specials fit inside the text vocab and sit below the byte block.
+    assert len(set(SPECIAL_TOKEN_IDS)) == len(SPECIAL_TOKEN_IDS)
+    for special in SPECIAL_TOKEN_IDS:
+        assert 0 <= special < TEXT_VOCAB
+        assert special < BYTE_ID_START  # disjoint from byte ids [192, 448)
+
+
+def test_vocab_layout_decomposes_to_519() -> None:
+    # 519 = 192 legacy symbols + 256 bytes + 71 conditioning slots.
+    assert BYTE_ID_START == 192
+    assert BYTE_ID_END == 448
+    assert BYTE_ID_END - BYTE_ID_START == 256
+    assert TEXT_VOCAB == 519
+    assert TEXT_VOCAB - BYTE_ID_END == 71
+
+
+def test_decode_skips_special_and_padding_ids(tokenizer: ZONOS2Tokenizer) -> None:
+    # Inject specials + the padding id (text_vocab) around the bytes for "Hi".
+    encoded = tokenizer.encode("Hi")
+    noisy = [TEXT_VOCAB, *SPECIAL_TOKEN_IDS, *encoded, TEXT_VOCAB, 500]
+    assert tokenizer.decode(noisy) == "Hi"
+
+
+def test_normalize_returns_str_passthrough_without_nemo(
+    tokenizer: ZONOS2Tokenizer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Force the optional-dependency import to fail so we exercise the fallback.
+    real_import = builtins.__import__
+
+    def _blocked_import(name: str, *args: object, **kwargs: object):
+        if name.startswith("nemo_text_processing"):
+            raise ImportError("nemo_text_processing is not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+    fresh = ZONOS2Tokenizer()
+    assert fresh.normalization_enabled is False
+    out = fresh.normalize("$5.32 on 1/2")
+    assert isinstance(out, str)
+    assert out == "$5.32 on 1/2"  # identity passthrough
+
+
+def test_decode_truncated_multibyte_does_not_raise(
+    tokenizer: ZONOS2Tokenizer,
+) -> None:
+    # A multi-byte char split mid-sequence (streaming / early stop) must
+    # degrade gracefully instead of raising UnicodeDecodeError.
+    truncated = tokenizer.encode("A你")[:3]  # BOS, 'A', first byte of CJK char
+    out = tokenizer.decode(truncated)
+    assert isinstance(out, str)
+    assert out.startswith("A")

--- a/mlx_audio/tts/models/zonos2/tokenizer.py
+++ b/mlx_audio/tts/models/zonos2/tokenizer.py
@@ -1,0 +1,139 @@
+"""ZONOS2 text tokenizer (UTF-8 byte vocab + special tokens).
+
+Mirrors the upstream byte-level text tokenizer used by the ZONOS2 TTS prompt
+builder. The base vocabulary is raw UTF-8 bytes; everything else is a fixed
+block of special / conditioning slots, exactly matching the released checkpoint
+layout (``text_vocab = 519``).
+
+Source of truth (Zyphra/ZONOS2):
+``python/zonos2/tts/prompt.py`` (``text_to_byte_ids``, ``SPECIAL_TOKEN_IDS``,
+``LEGACY_SYMBOL_VOCAB_SIZE``, ``BYTE_VOCAB_SIZE``) and
+``python/zonos2/tokenizer/textnorm.py`` (NeMo WFST text normalization).
+
+Layout of the ``text_vocab = 519`` id space:
+
+* ``0..191``  - legacy symbol ids. The first four are the named specials
+  ``PAD=0, UNK=1, BOS=2, EOS=3``; the remainder are reserved.
+* ``192..447`` - the 256 raw UTF-8 byte ids (byte ``b`` maps to ``b + 192``).
+* ``448..518`` - conditioning bucket slots (speaking-rate / quality /
+  speaker-background / accurate-mode). These are emitted by the prompt builder,
+  not by plain text ``encode`` / ``decode``.
+* ``519`` - the text padding id (``text_vocab`` itself); this is why the model
+  output vocab adds ``text_vocab + 1``.
+
+So ``519 = 192 (legacy symbols) + 256 (bytes) + 71 (conditioning slots)``.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional
+
+# --- special token ids (mirror upstream prompt.py SPECIAL_TOKEN_IDS) ---
+PAD_ID: int = 0
+UNK_ID: int = 1
+BOS_ID: int = 2
+EOS_ID: int = 3
+SPECIAL_TOKEN_IDS: tuple[int, ...] = (PAD_ID, UNK_ID, BOS_ID, EOS_ID)
+
+# --- vocab block sizes (mirror upstream prompt.py) ---
+LEGACY_SYMBOL_VOCAB_SIZE: int = 192
+BYTE_VOCAB_SIZE: int = 256
+BYTE_TEXT_VOCAB_SIZE: int = LEGACY_SYMBOL_VOCAB_SIZE + BYTE_VOCAB_SIZE  # 448
+
+# First / last raw-byte id (bytes occupy a contiguous block above the symbols).
+BYTE_ID_START: int = LEGACY_SYMBOL_VOCAB_SIZE  # 192
+BYTE_ID_END: int = BYTE_TEXT_VOCAB_SIZE  # 448 (exclusive)
+
+# Released-checkpoint text vocabulary size; the padding id equals this value.
+TEXT_VOCAB: int = 519
+
+
+def _load_nemo_normalizer() -> Optional[Callable[[str], str]]:
+    """Return a ``text -> str`` English NeMo normalizer, or ``None``.
+
+    Imports ``nemo_text_processing`` lazily so that ``pynini`` /
+    ``nemo_text_processing`` are never a hard dependency. Any import or
+    construction failure degrades gracefully to ``None`` (identity passthrough).
+    The bundled normalizer is English-only; multilingual routing is left to the
+    integration layer.
+    """
+    try:
+        from nemo_text_processing.text_normalization.normalize import Normalizer
+    except Exception:  # noqa: BLE001 - optional dependency, any failure -> fallback
+        return None
+
+    try:
+        normalizer = Normalizer(input_case="cased", lang="en")
+    except Exception:  # noqa: BLE001 - construction may fail without pynini
+        return None
+
+    def _normalize(text: str) -> str:
+        try:
+            result = normalizer.normalize(text, punct_post_process=True)
+        except Exception:  # noqa: BLE001 - normalization must never fail tokenization
+            return text
+        return result if isinstance(result, str) and result.strip() else text
+
+    return _normalize
+
+
+class ZONOS2Tokenizer:
+    """UTF-8 byte tokenizer for ZONOS2 text columns.
+
+    ``encode`` wraps the UTF-8 bytes of the input with ``BOS`` / ``EOS`` and
+    offsets each byte by :data:`LEGACY_SYMBOL_VOCAB_SIZE`, matching upstream
+    ``text_to_byte_ids``. ``decode`` is the exact inverse over the byte block and
+    skips any special / conditioning / padding ids, guaranteeing
+    ``decode(encode(s)) == s`` for every valid UTF-8 string.
+    """
+
+    pad_id: int = PAD_ID
+    unk_id: int = UNK_ID
+    bos_id: int = BOS_ID
+    eos_id: int = EOS_ID
+    text_vocab: int = TEXT_VOCAB
+    byte_id_start: int = BYTE_ID_START
+    byte_id_end: int = BYTE_ID_END
+
+    def __init__(self) -> None:
+        # Resolved once; ``None`` means identity passthrough.
+        self._normalizer: Optional[Callable[[str], str]] = _load_nemo_normalizer()
+
+    @property
+    def normalization_enabled(self) -> bool:
+        """True when a NeMo normalizer was loaded; False for identity fallback."""
+        return self._normalizer is not None
+
+    def normalize(self, text: str) -> str:
+        """Written -> spoken text normalization (English).
+
+        Uses ``nemo_text_processing`` (NeMo WFST) when importable, otherwise
+        returns ``text`` unchanged. Never raises on normalizer failure.
+        """
+        normalizer = self._normalizer
+        if normalizer is None:
+            return text
+        return normalizer(text)
+
+    def encode(self, text: str) -> List[int]:
+        """Encode text to ids: ``[BOS, *(byte + 192), EOS]``."""
+        return [
+            BOS_ID,
+            *(byte + LEGACY_SYMBOL_VOCAB_SIZE for byte in text.encode("utf-8")),
+            EOS_ID,
+        ]
+
+    def decode(self, ids: List[int]) -> str:
+        """Decode ids back to text, dropping non-byte (special/pad) ids.
+
+        Uses ``errors="replace"`` so a truncated multi-byte sequence (e.g. from
+        early-stopped or streamed model output) degrades gracefully instead of
+        raising; ``encode`` always emits complete UTF-8, so round-trips stay
+        exact.
+        """
+        raw = bytes(
+            token - LEGACY_SYMBOL_VOCAB_SIZE
+            for token in ids
+            if BYTE_ID_START <= token < BYTE_ID_END
+        )
+        return raw.decode("utf-8", errors="replace")


### PR DESCRIPTION
Implements `mlx_audio/tts/models/zonos2/tokenizer.py` per CONTRACT.md, mirroring upstream Zyphra/ZONOS2 `python/zonos2/tts/prompt.py` + `tokenizer/textnorm.py`.

## What
- `ZONOS2Tokenizer.encode(text) -> list[int]` = `[BOS, *(byte+192), EOS]` (mirror of upstream `text_to_byte_ids`).
- `decode(ids) -> str` is the exact inverse over the byte block `[192, 448)`, skipping special/conditioning/padding ids. Uses `errors="replace"` so a truncated multi-byte sequence (streamed / early-stopped output) degrades gracefully; `encode` always emits complete UTF-8 so round-trips stay exact.
- Specials `PAD/UNK/BOS/EOS = 0/1/2/3`. `text_vocab = 519 = 192 legacy symbols + 256 bytes + 71 conditioning slots`; padding id == `text_vocab`.
- `normalize(text) -> str` hook: uses `nemo_text_processing` (NeMo WFST) when importable, else identity passthrough. Lazy `try/except` import — no hard `pynini`/`nemo_text_processing` dependency.

## Tests (synthetic, no GPU/weights)
`mlx_audio/tts/models/zonos2/tests/test_tokenizer.py` — byte round-trip (ASCII + CJK/emoji), BOS/EOS wrapping, special-id range & disjointness from byte ids, vocab decomposition to 519, decode skipping specials, graceful truncated-multibyte decode, and the NeMo-absent fallback (monkeypatched `__import__`). 15 passed.

Scope: only `tokenizer.py` + its test. No edits to `__init__.py`/`config.py`. Phase-D integration is the coordinator's.