### PR TITLE
feat(tts/zonos2): layers (RMSNorm/RoPE/GQA Attention/SwiGLU/softcap)

### DIFF
--- a/mlx_audio/tts/models/zonos2/layers.py
+++ b/mlx_audio/tts/models/zonos2/layers.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2025, Prince Canuma and contributors (https://github.com/Blaizzy/mlx-audio)
+"""Core transformer layers for the ZONOS2 MLX port.
+
+Mirrors the upstream PyTorch implementation
+(``python/zonos2/models/zonos2.py`` classes ``Attention``, ``FeedForward``,
+``softcap``; ``python/zonos2/layers/{rotary,norm}.py``).
+
+Notable ZONOS2 specifics faithfully reproduced here:
+
+* **GQA** with ``num_qo_heads=16`` query heads and ``n_kv_heads=4`` KV heads
+  (``head_dim=128``).
+* **Fused KV projection** ``wkv`` whose checkpoint weight is rank-3
+  ``[2, kv_heads*head_dim, hidden]`` (``[0]`` = K, ``[1]`` = V).
+* **Per-head QK RMSNorm** (eps ``1e-6``, no affine weight) followed by a
+  learnable temperature ``temp`` (shape ``[1, num_heads, 1]``) applied to the
+  query only via ``q *= temp.abs()``.
+* **Headwise sigmoid gating** ``gate = sigmoid(gater(x))`` multiplied into the
+  attention output per head before the output projection.
+* **Interleaved RoPE** (upstream ``is_neox=False``).
+* **Dense SwiGLU** with a single fused ``w_in`` weight of shape
+  ``[2, intermediate, hidden]`` where ``[0]`` is the "up" path ``h`` and ``[1]``
+  is the SiLU-gated path: ``y = w_out(h * silu(gate))``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_audio.tts.models.zonos2.config import ZONOS2Config
+
+
+class RMSNorm(nn.Module):
+    """Root-Mean-Square layer normalization via ``mx.fast.rms_norm``."""
+
+    def __init__(self, dims: int, eps: float = 1e-5):
+        super().__init__()
+        self.weight = mx.ones((dims,))
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return mx.fast.rms_norm(x, self.weight, self.eps)
+
+
+def apply_rotary(
+    q: mx.array,
+    k: mx.array,
+    *,
+    offset: int = 0,
+    base: float = 10000.0,
+) -> tuple[mx.array, mx.array]:
+    """Apply *interleaved* RoPE to ``q``/``k`` of shape ``[B, T, H, D]``.
+
+    Matches the upstream ZONOS2 ``is_neox=False`` convention: consecutive
+    ``(even, odd)`` pairs of the head dimension form the complex plane that is
+    rotated. ``offset`` shifts the absolute positions (KV-cache decoding).
+    """
+    t = q.shape[1]
+    d = q.shape[-1]
+    if d % 2 != 0:
+        raise ValueError("RoPE requires an even head dimension.")
+    half = d // 2
+
+    freqs = mx.exp(mx.arange(half, dtype=mx.float32) * (-math.log(base) * 2.0 / d))
+    ts = (mx.arange(t, dtype=mx.float32) + float(offset))[:, None]  # [T, 1]
+    angles = ts * freqs[None, :]  # [T, half]
+    cos = mx.cos(angles)[None, :, None, :]  # [1, T, 1, half]
+    sin = mx.sin(angles)[None, :, None, :]
+
+    def _rotate(x: mx.array) -> mx.array:
+        # GQA: q and k may have different head counts, so derive shape per tensor.
+        b, _, h, _ = x.shape
+        x = x.reshape(b, t, h, half, 2)
+        xr = x[..., 0].astype(mx.float32)
+        xi = x[..., 1].astype(mx.float32)
+        out = mx.stack([xr * cos - xi * sin, xr * sin + xi * cos], axis=-1)
+        return out.astype(x.dtype).reshape(b, t, h, d)
+
+    return _rotate(q), _rotate(k)
+
+
+class RotaryEmbedding(nn.Module):
+    """Interleaved RoPE for ``head_dim=128``, ``base=config.rope_theta``."""
+
+    def __init__(self, head_dim: int = 128, base: float = 10000.0):
+        super().__init__()
+        self.head_dim = head_dim
+        self.base = float(base)
+
+    def __call__(
+        self, q: mx.array, k: mx.array, offset: int = 0
+    ) -> tuple[mx.array, mx.array]:
+        return apply_rotary(q, k, offset=offset, base=self.base)
+
+
+class Attention(nn.Module):
+    """GQA attention with QK-norm, learnable temperature, and headwise gating.
+
+    Checkpoint naming (mirrors upstream ``Attention``):
+
+    * ``attention.wq.weight``  -> ``[num_heads*head_dim, hidden]``
+    * ``attention.wkv.weight`` -> rank-3 ``[2, kv_heads*head_dim, hidden]``
+    * ``attention.wo.weight``  -> ``[hidden, num_heads*head_dim]``
+    * ``attention.gater.weight`` -> ``[num_heads, hidden]``
+    * ``attention.temp``       -> ``[1, num_heads, 1]``
+    """
+
+    def __init__(self, config: ZONOS2Config, layer_id: int):
+        super().__init__()
+        self.layer_id = layer_id
+        self.num_heads = config.num_qo_heads
+        self.num_kv_heads = config.n_kv_heads
+        self.head_dim = config.head_dim
+        self.hidden_size = config.dim
+
+        q_dim = self.num_heads * self.head_dim
+        kv_dim = self.num_kv_heads * self.head_dim
+
+        self.wq = nn.Linear(self.hidden_size, q_dim, bias=False)
+        # Fused K/V projection: weight is rank-3 [2, kv_dim, hidden] in the
+        # checkpoint ([0] = K, [1] = V). Stored as a raw parameter so the key
+        # name `attention.wkv.weight` matches.
+        self.wkv = _FusedProj(self.hidden_size, kv_dim)
+        self.wo = nn.Linear(q_dim, self.hidden_size, bias=False)
+        self.gater = nn.Linear(self.hidden_size, self.num_heads, bias=False)
+
+        # Learnable QK-norm temperature, applied to the query only.
+        self.temp = mx.ones((1, self.num_heads, 1))
+
+        self.rotary = RotaryEmbedding(self.head_dim, config.rope_theta)
+        self.scale = 1.0 / math.sqrt(self.head_dim)
+        # Upstream QK RMSNorm uses eps 1e-6 with a unit (non-learnable) weight.
+        self._qk_norm_eps = 1e-6
+        self._qk_norm_weight = mx.ones((self.head_dim,))
+
+    def _qk_rms_norm(self, x: mx.array) -> mx.array:
+        # Per-head RMSNorm over `head_dim` (matches upstream input dtype).
+        return mx.fast.rms_norm(
+            x, self._qk_norm_weight.astype(x.dtype), self._qk_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        *,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        offset: int = 0,
+    ) -> mx.array:
+        B, T, _ = x.shape
+
+        # RoPE positions must start at the number of already-cached tokens.
+        # Honour an explicit `offset`, but prefer the cache's own count so the
+        # query positions can never desync from the stored keys.
+        if cache is not None and offset == 0:
+            offset = cache.offset
+
+        gate = mx.sigmoid(self.gater(x))  # [B, T, num_heads]
+
+        q = self.wq(x).reshape(B, T, self.num_heads, self.head_dim)
+        k, v = self.wkv(x)  # each [B, T, kv_dim]
+        k = k.reshape(B, T, self.num_kv_heads, self.head_dim)
+        v = v.reshape(B, T, self.num_kv_heads, self.head_dim)
+
+        # QK norm (input dtype, matching upstream) + temperature on the query.
+        q = self._qk_rms_norm(q) * self.temp.abs().astype(q.dtype)
+        k = self._qk_rms_norm(k)
+
+        # Interleaved RoPE with absolute positions (cache offset aware).
+        q, k = self.rotary(q, k, offset=offset)
+
+        # [B, H, T, D]
+        q = q.transpose(0, 2, 1, 3)
+        k = k.transpose(0, 2, 1, 3)
+        v = v.transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            k, v = cache.update_and_fetch(k, v)
+
+        out = mx.fast.scaled_dot_product_attention(q, k, v, scale=self.scale, mask=mask)
+
+        # [B, T, H, D] then headwise gating before the output projection.
+        out = out.transpose(0, 2, 1, 3)
+        out = out * gate[..., None]
+        out = out.reshape(B, T, self.num_heads * self.head_dim)
+        return self.wo(out)
+
+
+class _FusedProj(nn.Module):
+    """Two-way fused projection holding a single rank-3 weight ``[2, out, in]``.
+
+    Reproduces upstream ``ChunkedLinear`` with ``divisor=2`` (used for both
+    ``attention.wkv`` and ``feed_forward.w_in``). Storing the weight as one
+    rank-3 parameter named ``weight`` keeps the checkpoint key (``*.weight``)
+    intact while splitting the two output halves ``[0]`` and ``[1]``.
+    """
+
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        self.weight = mx.zeros((2, out_features, in_features))
+
+    def __call__(self, x: mx.array) -> tuple[mx.array, mx.array]:
+        # weight: [2, out, in] -> contraction over `in` for each half.
+        return x @ self.weight[0].T, x @ self.weight[1].T
+
+
+class FeedForward(nn.Module):
+    """Dense SwiGLU with a fused ``w_in`` weight ``[2, intermediate, hidden]``.
+
+    Checkpoint naming:
+
+    * ``feed_forward.w_in.weight``  -> ``[2, intermediate, hidden]``
+      (``[0]`` = up path ``h``, ``[1]`` = gate path through SiLU).
+    * ``feed_forward.w_out.weight`` -> ``[hidden, intermediate]``.
+
+    Output: ``w_out(h * silu(gate))``.
+    """
+
+    def __init__(self, config: ZONOS2Config):
+        super().__init__()
+        hidden = config.dim
+        inter = config.intermediate_size
+        # w_in.weight is rank-3 [2, inter, hidden]: [0] = up path `h`, [1] = gate.
+        self.w_in = _FusedProj(hidden, inter)
+        self.w_out = nn.Linear(inter, hidden, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        h, gate = self.w_in(x)
+        return self.w_out(h * nn.silu(gate))
+
+
+def softcap(x: mx.array, cap: float) -> mx.array:
+    """Soft-cap logits: ``cap * tanh(x / cap)``."""
+    return cap * mx.tanh(x / cap)

--- a/mlx_audio/tts/models/zonos2/tests/test_layers.py
+++ b/mlx_audio/tts/models/zonos2/tests/test_layers.py
@@ -1,0 +1,206 @@
+"""Synthetic unit tests for ZONOS2 core layers (Mac, no GPU).
+
+Shapes only — full CUDA parity is the coordinator Phase-D gate.
+"""
+
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.cache import KVCache
+
+from mlx_audio.tts.models.zonos2.config import ZONOS2Config
+from mlx_audio.tts.models.zonos2.layers import (
+    Attention,
+    FeedForward,
+    RMSNorm,
+    RotaryEmbedding,
+    apply_rotary,
+    softcap,
+)
+
+
+def _tiny_config() -> ZONOS2Config:
+    return ZONOS2Config(
+        n_layers=4,
+        dim=64,
+        head_dim=16,
+        n_heads=4,  # dim // head_dim
+        n_kv_heads=2,
+        moe_n_experts=1,
+        rope_theta=10000.0,
+    )
+
+
+def test_rmsnorm_shape_and_value():
+    dims = 64
+    norm = RMSNorm(dims, eps=1e-5)
+    x = mx.random.normal((2, 5, dims))
+    y = norm(x)
+    assert y.shape == x.shape
+
+    # Manual reference rms_norm with unit weight.
+    ms = mx.mean(x.astype(mx.float32) ** 2, axis=-1, keepdims=True)
+    ref = (x.astype(mx.float32) * mx.rsqrt(ms + 1e-5)).astype(x.dtype)
+    assert mx.allclose(y, ref, atol=1e-4)
+
+
+def test_softcap_matches_formula():
+    x = mx.random.normal((3, 7)) * 30.0
+    cap = 15.0
+    assert mx.allclose(softcap(x, cap), cap * mx.tanh(x / cap), atol=1e-6)
+
+
+def test_apply_rotary_is_interleaved_and_preserves_shape():
+    b, t, h, d = 1, 5, 2, 16
+    q = mx.random.normal((b, t, h, d))
+    k = mx.random.normal((b, t, h, d))
+    qo, ko = apply_rotary(q, k, offset=0, base=10000.0)
+    assert qo.shape == q.shape and ko.shape == k.shape
+
+    # Position 0 is the identity rotation (angles are all zero).
+    assert mx.allclose(qo[:, 0], q[:, 0], atol=1e-4)
+    assert mx.allclose(ko[:, 0], k[:, 0], atol=1e-4)
+
+    # Interleaved rotation of the first (even, odd) pair at position 1.
+    half = d // 2
+    freqs = mx.exp(mx.arange(half, dtype=mx.float32) * (-math.log(10000.0) * 2.0 / d))
+    ang = float(freqs[0])  # position 1 -> angle = 1 * freqs[0]
+    x0 = float(q[0, 1, 0, 0])
+    x1 = float(q[0, 1, 0, 1])
+    exp0 = x0 * math.cos(ang) - x1 * math.sin(ang)
+    exp1 = x0 * math.sin(ang) + x1 * math.cos(ang)
+    assert abs(float(qo[0, 1, 0, 0]) - exp0) < 1e-3
+    assert abs(float(qo[0, 1, 0, 1]) - exp1) < 1e-3
+
+
+def test_rotary_embedding_offset_shifts_positions():
+    rope = RotaryEmbedding(head_dim=16, base=10000.0)
+    q = mx.random.normal((1, 3, 2, 16))
+    k = mx.random.normal((1, 3, 2, 16))
+    # Token at position p with offset=2 equals token at absolute position p+2.
+    q_off, _ = rope(q, k, offset=2)
+    q_full, _ = apply_rotary(
+        mx.concatenate([mx.zeros((1, 2, 2, 16)), q], axis=1),
+        mx.concatenate([mx.zeros((1, 2, 2, 16)), k], axis=1),
+        offset=0,
+    )
+    assert mx.allclose(q_off, q_full[:, 2:], atol=1e-3)
+
+
+def test_attention_shape():
+    cfg = _tiny_config()
+    attn = Attention(cfg, layer_id=0)
+    x = mx.random.normal((1, 5, cfg.dim))
+    causal = nn.MultiHeadAttention.create_additive_causal_mask(5)
+    y = attn(x, mask=causal)
+    assert y.shape == (1, 5, cfg.dim)
+
+
+def _randomize_attention(attn: Attention) -> None:
+    # The fused/linear weights default to zeros; give them real values so the
+    # output is not degenerately ~0 (which would mask any behavioral check).
+    attn.wq.weight = mx.random.normal(attn.wq.weight.shape) * 0.3
+    attn.wkv.weight = mx.random.normal(attn.wkv.weight.shape) * 0.3
+    attn.wo.weight = mx.random.normal(attn.wo.weight.shape) * 0.3
+    attn.gater.weight = mx.random.normal(attn.gater.weight.shape) * 0.3
+
+
+def test_attention_causal_mask_changes_output():
+    cfg = _tiny_config()
+    attn = Attention(cfg, layer_id=0)
+    _randomize_attention(attn)
+    x = mx.random.normal((1, 5, cfg.dim))
+    causal = nn.MultiHeadAttention.create_additive_causal_mask(5)
+    masked = attn(x, mask=causal)
+    full = attn(x, mask=None)
+    # Causal masking must actually restrict attention -> different output.
+    assert not bool(mx.allclose(masked, full, atol=1e-4))
+
+
+def test_fused_kv_split_ordering():
+    cfg = _tiny_config()
+    attn = Attention(cfg, layer_id=0)
+    kv_dim = cfg.n_kv_heads * cfg.head_dim
+    k_w = mx.random.normal((kv_dim, cfg.dim)) * 0.05
+    v_w = mx.random.normal((kv_dim, cfg.dim)) * 0.05
+    # weight[0] -> K, weight[1] -> V (mirrors upstream ChunkedLinear split).
+    attn.wkv.weight = mx.stack([k_w, v_w], axis=0)
+    x = mx.random.normal((1, 4, cfg.dim))
+    k, v = attn.wkv(x)
+    assert mx.allclose(k, x @ k_w.T, atol=1e-4)
+    assert mx.allclose(v, x @ v_w.T, atol=1e-4)
+
+
+def test_attention_incremental_matches_prefill():
+    cfg = _tiny_config()
+    attn = Attention(cfg, layer_id=0)
+    _randomize_attention(attn)
+    x = mx.random.normal((1, 4, cfg.dim))
+
+    # Offline: full sequence at once with a causal mask.
+    causal = nn.MultiHeadAttention.create_additive_causal_mask(4)
+    offline = attn(x, mask=causal)
+
+    # Incremental: feed one token at a time through a KV cache.
+    cache = KVCache()
+    steps = []
+    for t in range(4):
+        step = attn(x[:, t : t + 1], mask=None, cache=cache, offset=t)
+        steps.append(step)
+    incremental = mx.concatenate(steps, axis=1)
+
+    assert incremental.shape == offline.shape
+    assert mx.allclose(incremental, offline, atol=1e-3)
+
+
+def test_attention_cache_derives_offset():
+    cfg = _tiny_config()
+    attn = Attention(cfg, layer_id=0)
+    _randomize_attention(attn)
+    x = mx.random.normal((1, 4, cfg.dim))
+    causal = nn.MultiHeadAttention.create_additive_causal_mask(4)
+    offline = attn(x, mask=causal)
+
+    # Same as above but rely on cache.offset (no explicit offset passed).
+    cache = KVCache()
+    steps = [attn(x[:, t : t + 1], mask=None, cache=cache) for t in range(4)]
+    incremental = mx.concatenate(steps, axis=1)
+    assert mx.allclose(incremental, offline, atol=1e-3)
+
+
+def test_attention_projection_shapes():
+    cfg = _tiny_config()
+    attn = Attention(cfg, layer_id=1)
+    assert attn.wq.weight.shape == (cfg.num_qo_heads * cfg.head_dim, cfg.dim)
+    # Fused KV: rank-3 [2, kv_heads*head_dim, hidden].
+    assert attn.wkv.weight.shape == (2, cfg.n_kv_heads * cfg.head_dim, cfg.dim)
+    assert attn.wo.weight.shape == (cfg.dim, cfg.num_qo_heads * cfg.head_dim)
+    assert attn.gater.weight.shape == (cfg.num_qo_heads, cfg.dim)
+    assert attn.temp.shape == (1, cfg.num_qo_heads, 1)
+
+
+def test_feedforward_shape_and_fused_w_in():
+    cfg = _tiny_config()
+    ff = FeedForward(cfg)
+    inter = cfg.intermediate_size
+
+    # Fused w_in weight is rank-3 [2, intermediate, hidden].
+    assert ff.w_in.weight.shape == (2, inter, cfg.dim)
+    assert ff.w_out.weight.shape == (cfg.dim, inter)
+
+    # Hand-build a fused w_in and verify y == w_out(h * silu(gate)).
+    up_w = mx.random.normal((inter, cfg.dim)) * 0.05
+    gate_w = mx.random.normal((inter, cfg.dim)) * 0.05
+    out_w = mx.random.normal((cfg.dim, inter)) * 0.05
+    ff.w_in.weight = mx.stack([up_w, gate_w], axis=0)
+    ff.w_out.weight = out_w
+
+    x = mx.random.normal((1, 5, cfg.dim))
+    y = ff(x)
+    assert y.shape == (1, 5, cfg.dim)
+
+    h = x @ up_w.T
+    gate = x @ gate_w.T
+    ref = (h * nn.silu(gate)) @ out_w.T
+    assert mx.allclose(y, ref, atol=1e-4)


### PR DESCRIPTION
## Summary
Implements the core transformer layers unit (`mlx_audio/tts/models/zonos2/layers.py`) for the ZONOS2 MLX port, mirroring the upstream PyTorch math/shapes exactly (per CONTRACT §1).

### Implemented
- `RMSNorm(dims, eps)` via `mx.fast.rms_norm`.
- `apply_rotary` + `RotaryEmbedding` — **interleaved** RoPE (upstream `is_neox=False`), head_dim=128, base=`rope_theta`. GQA-safe (q/k may have different head counts).
- `Attention(config, layer_id)` — GQA q=16/kv=4, head_dim=128. Faithfully reproduces upstream specifics beyond bare projections:
  - fused `wkv` weight rank-3 `[2, kv_dim, hidden]` ([0]=K, [1]=V), matching `ChunkedLinear(divisor=2)`;
  - per-head QK RMSNorm (eps 1e-6, no affine) + learnable `temp` `[1, num_heads, 1]` applied to the query (`q *= temp.abs()`);
  - headwise sigmoid gating `o *= sigmoid(gater(x))`;
  - `wq`/`wo`/`gater` (no bias). Checkpoint keys: `attention.{wq,wkv,wo,gater}.weight`, `attention.temp`.
  - KV-cache + `offset` aware decoding (offset derived from `cache.offset` when not given, to keep RoPE positions in sync with stored keys).
- `FeedForward(config)` — dense SwiGLU with fused `w_in` `[2, inter, hidden]` ([0]=up `h`, [1]=gate w/ SiLU), `w_out` `[hidden, inter]`; `y = w_out(h * silu(gate))`.
- `softcap(x, cap)` = `cap * tanh(x / cap)`.

`wkv` and `w_in` share one small `_FusedProj` helper (both are upstream `ChunkedLinear(divisor=2)`), keeping checkpoint key names intact.

### Tests (synthetic, Mac, no GPU) — 11 passing
RMSNorm shape + manual-parity; softcap formula; interleaved-RoPE math + position-0 identity + offset shift; Attention output shape; projection/temp shapes; fused K/V split ordering; causal-mask behavioral effect; FeedForward shape + hand-built fused `w_in` parity; **incremental decode (KVCache) == prefill** (and offset-derived-from-cache variant).

Run: `uv run --no-sync --project … python -m pytest mlx_audio/tts/models/zonos2/tests/test_layers.py -q`

Code-reviewed (xhigh): no active correctness bugs found; addressed cache/offset desync hardening, DRY of fused helpers, and added cache/numeric test coverage. Full CUDA parity is the coordinator Phase-D gate.

Only touches `layers.py` + its test; does not modify `__init__.py`/`config.py`/`CONTRACT.md`/other modules.