### PR TITLE
feat(tts/zonos2): torch→MLX weight converter (sonic w13 split)

### DIFF
--- a/mlx_audio/tts/models/zonos2/convert.py
+++ b/mlx_audio/tts/models/zonos2/convert.py
@@ -1,0 +1,376 @@
+"""Convert Zyphra ZONOS2 (sparse-MoE multi-codebook AR TTS) weights to MLX.
+
+Loads the upstream PyTorch ``model.pth`` state-dict, remaps keys to the MLX
+layout used by this port, applies the bf16/fp32 dtype policy, and writes
+``model.safetensors`` (+ ``config.json`` derived from ``params.json`` if present).
+
+The key remapping mirrors the upstream loaders:
+  - ``python/zonos2/models/weight.py``  -> ``_normalize_zonos2_state_dict``
+    (weight-norm parametrization stripping, drops training-only router stats).
+  - ``python/zonos2/models/zonos2.py``  -> ``FusedGroupedExperts.load_state_dict``
+    / ``_convert_sonic_w13_to_gate_up`` (de-interleave the fused SonicMoE ``w13``).
+
+Unlike upstream, which keeps the experts FUSED as ``gate_up_proj``, this port
+targets ``mlx_lm.models.switch_layers.SwitchGLU`` which expects SEPARATE
+``gate_proj`` / ``up_proj`` / ``down_proj`` stacked-expert weights, so the
+SonicMoE ``w13`` is split into two tensors rather than re-concatenated.
+
+The remap core (:func:`remap_state_dict`, :func:`split_sonic_w13`) operates on a
+plain ``dict[str, mx.array]`` so it can be unit-tested without ``torch``; the
+``torch`` dependency is imported lazily inside :func:`convert` only.
+
+Usage:
+    python -m mlx_audio.tts.models.zonos2.convert \\
+        --model /path/to/zonos2 \\
+        --output ./models/zonos2-mlx \\
+        --dtype bfloat16
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Tuple
+
+import mlx.core as mx
+
+# ── target MLX key layout (single source of truth for the integration layer) ──
+#
+# Dense FFN (layers 0/1/2/27):   layers.{N}.feed_forward.w_in.weight  [2, inter, hidden]
+#                                layers.{N}.feed_forward.w_out.weight [hidden, inter]
+# MoE experts (SonicMoE, 3..26): de-interleaved into SwitchGLU stacked weights ->
+#   layers.{N}.feed_forward.switch_mlp.gate_proj.weight  [E, inter, hidden]
+#   layers.{N}.feed_forward.switch_mlp.up_proj.weight    [E, inter, hidden]
+#   layers.{N}.feed_forward.switch_mlp.down_proj.weight  [E, hidden, inter]
+SWITCH_MLP_PREFIX = "feed_forward.switch_mlp"
+
+# Fused SonicMoE experts checkpoint key suffixes (relative to the FFN prefix).
+SONIC_W13_SUFFIX = "feed_forward.experts.w13"
+SONIC_W2_SUFFIX = "feed_forward.experts.w2"
+
+# Training-only router statistics that upstream drops for inference.
+_ROUTER_TRAINING_ONLY = (".router.ent_denom", ".router.normalized_entropy")
+
+# Tensors kept in fp32 for numerical parity (norms, router, scales/biases).
+_FP32_SUBSTRINGS = (
+    "norm",  # *_norm.weight, rmsnorm*, attention_norm, ffn_norm, final norm
+    "router.",  # the entire router sub-tree
+    "balancing_biases",
+    "router_states_scale",
+)
+
+
+# ── MoE de-interleave (mirror upstream _convert_sonic_w13_to_gate_up) ─────────
+
+
+def split_sonic_w13(w13: mx.array) -> Tuple[mx.array, mx.array]:
+    """De-interleave a fused SonicMoE ``w13`` into separate gate/up projections.
+
+    Upstream fuses the SwiGLU input projection as a single rank-3 tensor
+    ``[experts, 2 * intermediate, hidden]`` with gate and up rows INTERLEAVED:
+    even rows are the gate (SiLU branch), odd rows are the up branch. Mirrors
+    ``zonos2.models.zonos2._convert_sonic_w13_to_gate_up`` (which then re-concats
+    them; here we keep them separate for ``SwitchGLU``).
+
+    Returns:
+        ``(gate, up)`` each shaped ``[experts, intermediate, hidden]``.
+    """
+    if w13.ndim != 3:
+        raise ValueError(f"Expected SonicMoE w13 to be rank-3, got shape {w13.shape}")
+    if w13.shape[1] % 2 != 0:
+        raise ValueError(f"Expected even fused width in SonicMoE w13, got {w13.shape}")
+    gate = w13[:, 0::2, :]
+    up = w13[:, 1::2, :]
+    return gate, up
+
+
+# ── weight-norm parametrization stripping ─────────────────────────────────────
+
+
+def _strip_weight_norm(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+    """Collapse ``*.parametrizations.X.original*`` keys back to plain ``*.X``.
+
+    Mirrors ``zonos2.models.weight._normalize_zonos2_state_dict`` for the common
+    case where the parametrization stores a single ``.original`` (a straight
+    rename: ``a.parametrizations.weight.original`` -> ``a.weight``).
+
+    Additionally reconstructs the modern two-tensor
+    ``torch.nn.utils.parametrizations.weight_norm`` form when BOTH
+    ``original0`` (magnitude ``g``) and ``original1`` (direction ``v``) are
+    present: ``w = g * v / ||v||`` with the norm taken over every dim except 0.
+    """
+    result: Dict[str, mx.array] = {}
+    pending_pairs: Dict[str, Dict[str, mx.array]] = {}
+
+    for key, value in weights.items():
+        if ".parametrizations." not in key or ".original" not in key:
+            result[key] = value
+            continue
+
+        base = key.replace(".parametrizations.", ".")
+        if base.endswith(".original0") or base.endswith(".original1"):
+            target = base[: -len(".original0")]  # drop ".originalN"
+            slot = "g" if base.endswith(".original0") else "v"
+            pending_pairs.setdefault(target, {})[slot] = value
+        elif base.endswith(".original"):
+            # Single ".original" -> strip only the trailing marker (anchored, so
+            # a path segment that merely contains "original" is left intact).
+            result[base[: -len(".original")]] = value
+        else:
+            result[base] = value
+
+    for target, parts in pending_pairs.items():
+        if "g" in parts and "v" in parts:
+            result[target] = _reconstruct_weight_norm(parts["g"], parts["v"])
+        else:
+            # Only one half present: keep it under the collapsed name so nothing
+            # is silently dropped (lets the caller notice the malformed pair).
+            (only,) = parts.values()
+            result[target] = only
+
+    return result
+
+
+def _reconstruct_weight_norm(g: mx.array, v: mx.array) -> mx.array:
+    """Recompute the effective weight from weight-norm parts (``dim=0`` default).
+
+    ``g`` is the per-output-channel magnitude ``[out, 1, ...]``; ``v`` is the
+    direction with the full weight shape. The L2 norm of ``v`` is taken over all
+    dims except 0, matching PyTorch's ``_WeightNorm`` forward.
+    """
+    reduce_axes = tuple(range(1, v.ndim))
+    v32 = v.astype(mx.float32)
+    norm = mx.sqrt(mx.sum(v32 * v32, axis=reduce_axes, keepdims=True))
+    # Return fp32; the caller's dtype policy decides the final precision.
+    return g.astype(mx.float32) * (v32 / norm)
+
+
+# ── dtype policy ──────────────────────────────────────────────────────────────
+
+
+def _target_dtype(key: str, weight_dtype: mx.Dtype) -> mx.Dtype:
+    """Norms / router / scale-and-bias tensors stay fp32; everything else casts."""
+    if any(sub in key for sub in _FP32_SUBSTRINGS):
+        return mx.float32
+    return weight_dtype
+
+
+# ── core remap (pure MLX, torch-free, unit-testable) ─────────────────────────
+
+
+def remap_state_dict(
+    weights: Dict[str, mx.array], weight_dtype: mx.Dtype
+) -> Dict[str, mx.array]:
+    """Remap an MLX-array ZONOS2 state-dict to this port's layout + dtype policy.
+
+    Steps (mirroring the upstream loaders):
+      1. Strip weight-norm parametrization (``*.parametrizations.X.original*``).
+      2. Drop training-only router statistics.
+      3. De-interleave each MoE ``feed_forward.experts.w13`` into separate
+         ``switch_mlp.gate_proj``/``up_proj`` weights and rename ``w2`` ->
+         ``switch_mlp.down_proj`` (dense ``feed_forward.w_in``/``w_out`` are
+         passed through unchanged).
+      4. Apply the bf16/fp32 dtype policy.
+    """
+    weights = _strip_weight_norm(weights)
+
+    remapped: Dict[str, mx.array] = {}
+
+    def _put(target: str, value: mx.array) -> None:
+        if target in remapped:
+            raise ValueError(f"Duplicate target key after remap: {target!r}")
+        remapped[target] = value
+
+    for key, value in weights.items():
+        if any(stat in key for stat in _ROUTER_TRAINING_ONLY):
+            continue
+
+        if key.endswith(SONIC_W13_SUFFIX):
+            prefix = key[: -len(SONIC_W13_SUFFIX)]  # e.g. "layers.5."
+            gate, up = split_sonic_w13(value)
+            _put(f"{prefix}{SWITCH_MLP_PREFIX}.gate_proj.weight", gate)
+            _put(f"{prefix}{SWITCH_MLP_PREFIX}.up_proj.weight", up)
+            continue
+
+        if key.endswith(SONIC_W2_SUFFIX):
+            prefix = key[: -len(SONIC_W2_SUFFIX)]
+            _put(f"{prefix}{SWITCH_MLP_PREFIX}.down_proj.weight", value)
+            continue
+
+        _put(key, value)
+
+    return {k: v.astype(_target_dtype(k, weight_dtype)) for k, v in remapped.items()}
+
+
+# ── torch -> MLX loading ──────────────────────────────────────────────────────
+
+
+def _torch_state_dict_to_mx(state_dict: Dict[str, object]) -> Dict[str, mx.array]:
+    """Convert a torch state-dict to ``{key: mx.array}``.
+
+    Floating tensors are upcast to fp32 before ``.numpy()`` because numpy has no
+    native bf16 (the real per-key dtype is applied later by the dtype policy).
+    Integer / bool tensors keep their native dtype so index/pad buffers are not
+    corrupted into floats.
+    """
+    out: Dict[str, mx.array] = {}
+    for key, tensor in state_dict.items():
+        tensor = tensor.detach().to("cpu")
+        if tensor.is_floating_point():
+            tensor = tensor.float()
+        out[key] = mx.array(tensor.numpy())
+    return out
+
+
+def _load_torch_state_dict(pth_path: Path) -> Dict[str, object]:
+    import torch  # lazy: torch is only needed for real conversion, not tests
+
+    obj = torch.load(str(pth_path), map_location="cpu", weights_only=False)
+    if isinstance(obj, dict) and "model" in obj and isinstance(obj["model"], dict):
+        return obj["model"]
+    if isinstance(obj, dict) and "state_dict" in obj:
+        return obj["state_dict"]
+    return obj
+
+
+# ── config.json from params.json ──────────────────────────────────────────────
+
+
+def _write_config(src_dir: Path, out_dir: Path, dtype: str) -> None:
+    """Copy ``params.json`` (raw ZONOS2 field names) to ``config.json``, set dtype.
+
+    ``ZONOS2Config.from_dict`` filters to its known fields, so the raw
+    ``params.json`` field names are the source of truth and pass through as-is.
+    """
+    params_path = src_dir / "params.json"
+    if not params_path.exists():
+        print(
+            f"  WARNING: no params.json next to the checkpoint ({src_dir}); "
+            "config.json was NOT written — the MLX model dir will be incomplete"
+        )
+        return
+    with open(params_path) as f:
+        params = json.load(f)
+    params["dtype"] = dtype
+    with open(out_dir / "config.json", "w") as f:
+        json.dump(params, f, indent=2)
+    print(f"  wrote config.json from {params_path.name}")
+
+
+_DTYPE_MAP = {"float32": mx.float32, "float16": mx.float16, "bfloat16": mx.bfloat16}
+
+
+def convert(pth_path: str | Path, out_dir: str | Path, dtype: str = "bfloat16") -> Path:
+    """Convert a ZONOS2 ``model.pth`` to an MLX ``model.safetensors`` directory.
+
+    Args:
+        pth_path: path to the torch ``model.pth`` (or its parent directory).
+        out_dir: output directory for ``model.safetensors`` (+ ``config.json``).
+        dtype: target weight dtype (``"bfloat16"`` / ``"float16"`` / ``"float32"``);
+            norms/router/scale tensors are always written as fp32.
+
+    Returns:
+        The output directory as a ``Path``.
+    """
+    if dtype not in _DTYPE_MAP:
+        raise ValueError(
+            f"Unsupported dtype {dtype!r}; choose one of {list(_DTYPE_MAP)}"
+        )
+    weight_dtype = _DTYPE_MAP[dtype]
+
+    pth_path = Path(pth_path)
+    src_dir = pth_path.parent if pth_path.is_file() else pth_path
+    if pth_path.is_dir():
+        pth_path = pth_path / "model.pth"
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading torch checkpoint {pth_path}…")
+    torch_state = _load_torch_state_dict(pth_path)
+    weights = _torch_state_dict_to_mx(torch_state)
+    print(f"  {len(weights)} tensors")
+
+    weights = remap_state_dict(weights, weight_dtype)
+
+    out_path = out_dir / "model.safetensors"
+    mx.save_safetensors(str(out_path), weights)
+    size_mb = out_path.stat().st_size / 1e6
+    print(f"  saved {out_path.name} ({size_mb:.0f} MB, {len(weights)} tensors)")
+
+    _write_config(src_dir, out_dir, dtype)
+
+    print(f"Done → {out_dir}")
+    return out_dir
+
+
+# ── Qwen3 voice embedder conversion ───────────────────────────────────────────
+
+
+def convert_voice_embedder(
+    hf_repo: str = "marksverdhei/Qwen3-Voice-Embedding-12Hz-1.7B",
+    out_dir: str | Path = "./models/zonos2-voice-embedder-mlx",
+    dtype: str = "bfloat16",
+) -> Path:
+    """Convert the Qwen3-1.7B voice-embedder backbone (HF -> MLX safetensors).
+
+    The mlx-audio ``qwen3`` model reuses ``mlx_lm.models.qwen3`` (``Model`` /
+    ``ModelArgs``), so the HF -> MLX conversion is exactly the standard mlx_lm
+    qwen3 path (sanitize = drop tied ``lm_head.weight``). This delegates to
+    ``mlx_lm.convert`` rather than re-implementing the qwen3 sanitize logic.
+
+    NOTE: the voice embedder uses the qwen3 backbone hidden states (2048-D) as a
+    speaker embedding; the embedding-head / mel-frontend wiring is finalized by
+    the coordinator in ``speaker_encoder.py`` (CONTRACT.md §5). This produces the
+    plain MLX-format qwen3 weights that the embedder loads.
+
+    Args:
+        hf_repo: HuggingFace repo id for the voice-embedding Qwen3 backbone.
+        out_dir: output directory for the MLX model.
+        dtype: target weight dtype.
+
+    Returns:
+        The output directory as a ``Path``.
+    """
+    from mlx_lm import convert as mlx_lm_convert
+
+    out_dir = Path(out_dir)
+    print(f"Converting voice embedder {hf_repo} → {out_dir} (dtype={dtype})…")
+    mlx_lm_convert(hf_repo, str(out_dir), dtype=dtype)
+    print(f"Done → {out_dir}")
+    return out_dir
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert ZONOS2 to mlx-audio format")
+    parser.add_argument(
+        "--model", required=True, help="Path to model.pth or its parent directory"
+    )
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument(
+        "--dtype",
+        default="bfloat16",
+        choices=list(_DTYPE_MAP),
+        help="Target weight dtype (default: bfloat16)",
+    )
+    parser.add_argument(
+        "--voice-embedder",
+        default=None,
+        metavar="HF_REPO",
+        help="Also convert the Qwen3 voice embedder from this HF repo into "
+        "<output>/voice_embedder",
+    )
+    args = parser.parse_args()
+
+    out = convert(args.model, args.output, args.dtype)
+
+    if args.voice_embedder:
+        convert_voice_embedder(args.voice_embedder, out / "voice_embedder", args.dtype)
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_audio/tts/models/zonos2/tests/test_convert.py
+++ b/mlx_audio/tts/models/zonos2/tests/test_convert.py
@@ -1,0 +1,320 @@
+"""Synthetic-fixture tests for the ZONOS2 torch->MLX weight converter.
+
+No real 8B weights and no ``torch`` are required: a small in-memory MLX
+state-dict exercises every remap branch (parametrization strip, SonicMoE w13
+de-interleave, router pass-through, dtype policy). The full ``convert`` path is
+exercised by monkeypatching the torch loader so a fixture dict flows through the
+real save/reload + dtype-policy code.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+
+from mlx_audio.tts.models.zonos2 import convert as convert_mod
+from mlx_audio.tts.models.zonos2.convert import (
+    SWITCH_MLP_PREFIX,
+    _torch_state_dict_to_mx,
+    convert,
+    remap_state_dict,
+    split_sonic_w13,
+)
+
+HIDDEN = 8
+INTER = 4
+EXPERTS = 3
+
+
+def _interleaved_w13(gate: mx.array, up: mx.array) -> mx.array:
+    """Build a fused w13 [E, 2*inter, hidden] with gate=even rows, up=odd rows."""
+    e, inter, hidden = gate.shape
+    fused = mx.zeros((e, 2 * inter, hidden))
+    fused[:, 0::2, :] = gate
+    fused[:, 1::2, :] = up
+    return fused
+
+
+def _make_state_dict() -> dict[str, mx.array]:
+    """A synthetic ZONOS2 state-dict touching every remap branch."""
+    rng = np.random.default_rng(0)
+
+    def arr(*shape: int) -> mx.array:
+        return mx.array(rng.standard_normal(shape).astype(np.float32))
+
+    gate = arr(EXPERTS, INTER, HIDDEN)
+    up = arr(EXPERTS, INTER, HIDDEN)
+
+    return {
+        # embeddings / head -> pass through
+        "multi_embedder.embedders.0.weight": arr(1026, HIDDEN),
+        "multi_embedder.embedders.8.weight": arr(1026, HIDDEN),
+        "multi_output.weight": arr(9754, HIDDEN),
+        # dense FFN (fused w_in stays rank-3, untouched)
+        "layers.0.feed_forward.w_in.weight": arr(2, INTER, HIDDEN),
+        "layers.0.feed_forward.w_out.weight": arr(HIDDEN, INTER),
+        # norms -> fp32
+        "layers.0.attention_norm.weight": arr(HIDDEN),
+        "layers.0.ffn_norm.weight": arr(HIDDEN),
+        "norm.weight": arr(HIDDEN),
+        # MoE layer: fused SonicMoE experts -> split into gate/up/down
+        "layers.5.feed_forward.experts.w13": _interleaved_w13(gate, up),
+        "layers.5.feed_forward.experts.w2": arr(EXPERTS, HIDDEN, INTER),
+        # router -> pass through, fp32
+        "layers.5.feed_forward.router.down_proj.weight": arr(128, HIDDEN),
+        "layers.5.feed_forward.router.down_proj.bias": arr(128),
+        "layers.5.feed_forward.router.rmsnorm_eda.weight": arr(128),
+        "layers.5.feed_forward.router.router_mlp.0.weight": arr(128, 128),
+        "layers.5.feed_forward.router.router_mlp.0.bias": arr(128),
+        "layers.5.feed_forward.router.router_mlp.2.weight": arr(128, 128),
+        "layers.5.feed_forward.router.router_mlp.2.bias": arr(128),
+        "layers.5.feed_forward.router.router_mlp.4.weight": arr(16, 128),
+        "layers.5.feed_forward.router.balancing_biases": arr(16),
+        "layers.5.feed_forward.router.router_states_scale": arr(1),
+        # training-only router stats -> dropped
+        "layers.5.feed_forward.router.ent_denom": arr(1),
+        "layers.5.feed_forward.router.normalized_entropy": arr(1),
+        # weight-norm parametrization (modern original0/original1 pair)
+        "wn.parametrizations.weight.original0": arr(HIDDEN, 1),
+        "wn.parametrizations.weight.original1": arr(HIDDEN, HIDDEN),
+        # weight-norm parametrization (single .original -> straight rename)
+        "single.parametrizations.weight.original": arr(HIDDEN, HIDDEN),
+    }, (gate, up)
+
+
+# ── split_sonic_w13 ───────────────────────────────────────────────────────────
+
+
+def test_split_sonic_w13_deinterleaves_even_gate_odd_up():
+    gate = mx.arange(EXPERTS * INTER * HIDDEN).reshape(EXPERTS, INTER, HIDDEN)
+    up = gate + 1000.0
+    fused = _interleaved_w13(gate, up)
+
+    got_gate, got_up = split_sonic_w13(fused)
+
+    assert got_gate.shape == (EXPERTS, INTER, HIDDEN)
+    assert got_up.shape == (EXPERTS, INTER, HIDDEN)
+    assert mx.array_equal(got_gate, gate)
+    assert mx.array_equal(got_up, up)
+
+
+def test_split_sonic_w13_rejects_bad_rank_and_odd_width():
+    import pytest
+
+    with pytest.raises(ValueError):
+        split_sonic_w13(mx.zeros((EXPERTS, 2 * INTER)))  # rank-2
+    with pytest.raises(ValueError):
+        split_sonic_w13(mx.zeros((EXPERTS, 2 * INTER + 1, HIDDEN)))  # odd width
+
+
+# ── remap_state_dict ──────────────────────────────────────────────────────────
+
+
+def test_remap_strips_weight_norm_parametrization():
+    weights, _ = _make_state_dict()
+    out = remap_state_dict(weights, mx.bfloat16)
+
+    # parametrization keys gone, collapsed names present
+    assert not any(".parametrizations." in k for k in out)
+    assert "wn.weight" in out
+    assert "single.weight" in out
+    # single .original is a straight rename (values preserved up to dtype cast)
+    expected = weights["single.parametrizations.weight.original"].astype(mx.bfloat16)
+    assert mx.array_equal(out["single.weight"], expected)
+
+
+def test_remap_reconstructs_weight_norm_pair():
+    # Hand-built ground truth (independent of the implementation formula):
+    # row0 v=(3,4) -> ||v||=5, g=10 -> w=(6, 8); row1 v=(0,2) -> ||v||=2, g=4 -> w=(0,4).
+    weights = {
+        "wn.parametrizations.weight.original0": mx.array([[10.0], [4.0]]),
+        "wn.parametrizations.weight.original1": mx.array([[3.0, 4.0], [0.0, 2.0]]),
+    }
+    out = remap_state_dict(weights, mx.float32)
+    expected = mx.array([[6.0, 8.0], [0.0, 4.0]])
+    assert "wn.weight" in out
+    assert mx.allclose(out["wn.weight"], expected, atol=1e-5)
+
+
+def test_remap_splits_sonic_w13_into_gate_up_down():
+    weights, (gate, up) = _make_state_dict()
+    out = remap_state_dict(weights, mx.bfloat16)
+
+    gate_key = f"layers.5.{SWITCH_MLP_PREFIX}.gate_proj.weight"
+    up_key = f"layers.5.{SWITCH_MLP_PREFIX}.up_proj.weight"
+    down_key = f"layers.5.{SWITCH_MLP_PREFIX}.down_proj.weight"
+
+    assert gate_key in out and up_key in out and down_key in out
+    # fused source keys are consumed
+    assert "layers.5.feed_forward.experts.w13" not in out
+    assert "layers.5.feed_forward.experts.w2" not in out
+
+    assert out[gate_key].shape == (EXPERTS, INTER, HIDDEN)
+    assert out[up_key].shape == (EXPERTS, INTER, HIDDEN)
+    assert out[down_key].shape == (EXPERTS, HIDDEN, INTER)
+    # even rows -> gate, odd rows -> up (element-wise vs hand-built tensors)
+    assert mx.array_equal(out[gate_key], gate.astype(mx.bfloat16))
+    assert mx.array_equal(out[up_key], up.astype(mx.bfloat16))
+
+
+def test_remap_drops_training_only_router_stats():
+    weights, _ = _make_state_dict()
+    out = remap_state_dict(weights, mx.bfloat16)
+    assert not any(k.endswith(".router.ent_denom") for k in out)
+    assert not any(k.endswith(".router.normalized_entropy") for k in out)
+
+
+def test_remap_passes_through_embeddings_head_dense_and_router():
+    weights, _ = _make_state_dict()
+    out = remap_state_dict(weights, mx.bfloat16)
+    for key in (
+        "multi_embedder.embedders.0.weight",
+        "multi_embedder.embedders.8.weight",
+        "multi_output.weight",
+        "layers.0.feed_forward.w_in.weight",
+        "layers.0.feed_forward.w_out.weight",
+        "layers.5.feed_forward.router.down_proj.weight",
+        "layers.5.feed_forward.router.router_mlp.4.weight",
+        "layers.5.feed_forward.router.balancing_biases",
+        "layers.5.feed_forward.router.router_states_scale",
+    ):
+        assert key in out, f"missing pass-through key {key}"
+    # fused dense w_in keeps its rank-3 shape
+    assert out["layers.0.feed_forward.w_in.weight"].shape == (2, INTER, HIDDEN)
+
+
+def test_remap_dtype_policy():
+    weights, _ = _make_state_dict()
+    out = remap_state_dict(weights, mx.bfloat16)
+
+    # weights -> bf16
+    assert out["multi_output.weight"].dtype == mx.bfloat16
+    assert out["layers.0.feed_forward.w_in.weight"].dtype == mx.bfloat16
+    assert out[f"layers.5.{SWITCH_MLP_PREFIX}.gate_proj.weight"].dtype == mx.bfloat16
+    assert out[f"layers.5.{SWITCH_MLP_PREFIX}.down_proj.weight"].dtype == mx.bfloat16
+
+    # norms -> fp32
+    assert out["layers.0.attention_norm.weight"].dtype == mx.float32
+    assert out["layers.0.ffn_norm.weight"].dtype == mx.float32
+    assert out["norm.weight"].dtype == mx.float32
+
+    # router subtree + special scalars -> fp32
+    assert out["layers.5.feed_forward.router.down_proj.weight"].dtype == mx.float32
+    assert out["layers.5.feed_forward.router.router_mlp.4.weight"].dtype == mx.float32
+    assert out["layers.5.feed_forward.router.balancing_biases"].dtype == mx.float32
+    assert out["layers.5.feed_forward.router.router_states_scale"].dtype == mx.float32
+
+
+# ── full convert() path (torch loader monkeypatched) ──────────────────────────
+
+
+def test_convert_end_to_end_writes_safetensors(tmp_path, monkeypatch):
+    weights, (gate, up) = _make_state_dict()
+
+    # Bypass torch: feed the synthetic MLX dict straight into the pipeline.
+    monkeypatch.setattr(convert_mod, "_load_torch_state_dict", lambda _pth: weights)
+    monkeypatch.setattr(convert_mod, "_torch_state_dict_to_mx", lambda sd: dict(sd))
+
+    # params.json -> config.json passthrough (+ dtype patch)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "model.pth").write_bytes(b"")  # presence only; loader is patched
+    (src / "params.json").write_text('{"n_layers": 28, "dim": 2048}')
+
+    out_dir = tmp_path / "out"
+    returned = convert(src, out_dir, dtype="bfloat16")
+    assert returned == out_dir
+
+    st_path = out_dir / "model.safetensors"
+    assert st_path.exists()
+
+    reloaded = dict(mx.load(str(st_path)))
+    gate_key = f"layers.5.{SWITCH_MLP_PREFIX}.gate_proj.weight"
+    up_key = f"layers.5.{SWITCH_MLP_PREFIX}.up_proj.weight"
+
+    # remap survived the safetensors round-trip
+    assert gate_key in reloaded and up_key in reloaded
+    assert "layers.5.feed_forward.experts.w13" not in reloaded
+    assert not any(".parametrizations." in k for k in reloaded)
+    assert mx.array_equal(reloaded[gate_key], gate.astype(mx.bfloat16))
+    assert mx.array_equal(reloaded[up_key], up.astype(mx.bfloat16))
+
+    # dtype policy survived
+    assert reloaded["norm.weight"].dtype == mx.float32
+    assert reloaded["multi_output.weight"].dtype == mx.bfloat16
+
+    # config.json written from params.json with dtype patched
+    import json
+
+    cfg = json.loads((out_dir / "config.json").read_text())
+    assert cfg["n_layers"] == 28
+    assert cfg["dtype"] == "bfloat16"
+
+
+def test_convert_rejects_unknown_dtype(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError):
+        convert(tmp_path, tmp_path / "out", dtype="float8")
+
+
+# ── _torch_state_dict_to_mx (fake torch tensors, no torch import needed) ───────
+
+
+class _FakeTensor:
+    """Minimal stand-in for a torch.Tensor exposing the methods the loader uses."""
+
+    def __init__(self, np_array: np.ndarray, floating: bool):
+        self._a = np_array
+        self._floating = floating
+        self.float_called = False
+
+    def detach(self) -> "_FakeTensor":
+        return self
+
+    def to(self, _device: str) -> "_FakeTensor":
+        return self
+
+    def is_floating_point(self) -> bool:
+        return self._floating
+
+    def float(self) -> "_FakeTensor":
+        self.float_called = True
+        return _FakeTensor(self._a.astype(np.float32), True)
+
+    def numpy(self) -> np.ndarray:
+        return self._a
+
+
+def test_torch_loader_upcasts_floats_and_preserves_integers():
+    float_t = _FakeTensor(np.ones((2, 2), dtype=np.float16), floating=True)
+    int_t = _FakeTensor(np.array([1025, 1024], dtype=np.int64), floating=False)
+
+    out = _torch_state_dict_to_mx({"w": float_t, "pad_idx": int_t})
+
+    # floating tensor went through .float() (bf16/fp16 cannot hit numpy directly)
+    assert float_t.float_called is True
+    assert out["w"].dtype == mx.float32
+    # integer buffer kept its integer dtype and exact values (not floated)
+    assert int_t.float_called is False
+    assert out["pad_idx"].dtype == mx.int64
+    assert mx.array_equal(out["pad_idx"], mx.array([1025, 1024], dtype=mx.int64))
+
+
+# ── collision guard ───────────────────────────────────────────────────────────
+
+
+def test_remap_raises_on_target_key_collision():
+    import pytest
+
+    # A pre-existing split key colliding with what w13 would produce.
+    gate = mx.zeros((EXPERTS, INTER, HIDDEN))
+    up = mx.zeros((EXPERTS, INTER, HIDDEN))
+    weights = {
+        "layers.5.feed_forward.experts.w13": _interleaved_w13(gate, up),
+        f"layers.5.{SWITCH_MLP_PREFIX}.gate_proj.weight": mx.zeros(
+            (EXPERTS, INTER, HIDDEN)
+        ),
+    }
+    with pytest.raises(ValueError):
+        remap_state_dict(weights, mx.bfloat16)


### PR DESCRIPTION
## What

Implements `mlx_audio/tts/models/zonos2/convert.py` — the torch→MLX weight converter for the ZONOS2 port (CONTRACT.md §6), plus 12 synthetic-fixture tests.

`convert(pth, out, dtype)` loads the upstream `model.pth` state-dict, remaps keys to the MLX layout, applies the bf16/fp32 dtype policy, and writes `model.safetensors` (+ `config.json` from `params.json` if present).

## Remap (mirrors upstream loaders)

- **Weight-norm strip** (`weight.py:_normalize_zonos2_state_dict`): `*.parametrizations.X.original*` → `*.X`. Single `.original` is a suffix-anchored rename; an `original0`/`original1` pair is reconstructed as `g·v/‖v‖` (norm over dims≠0).
- **SonicMoE de-interleave** (`zonos2.py:_convert_sonic_w13_to_gate_up`): fused `feed_forward.experts.w13` `[E,2·inter,hidden]` → SEPARATE `feed_forward.switch_mlp.gate_proj.weight` (even rows) / `up_proj.weight` (odd rows) for `SwitchGLU`; `w2` → `down_proj.weight`. Provides `split_sonic_w13(w13) -> (gate, up)`.
- **Dense FFN**: fused rank-3 `feed_forward.w_in.weight` + `w_out.weight` pass through unchanged.
- **Pass-through**: `multi_embedder.embedders.{0..9}.weight` (text embedder is index 9), `multi_output.weight`, full `router.*` subtree.
- **Drop**: training-only `.router.ent_denom` / `.router.normalized_entropy`.
- **dtype**: weights→bf16; `*norm*` / `router.*` / `balancing_biases` / `router_states_scale`→fp32.

`convert_voice_embedder` delegates the Qwen3-1.7B voice-embedder HF→MLX conversion to `mlx_lm.convert` (reusing the qwen3 sanitize convention).

## Design notes

- Remap core (`remap_state_dict`, `split_sonic_w13`) is pure-MLX; `torch` is imported lazily inside `convert()` only, so the unit tests run with no torch and no real weights.
- Integer/bool buffers are preserved (not force-floated); `remap_state_dict` raises on target-key collisions.
- Constraint: only `convert.py` + `tests/test_convert.py` added.

## Test

`uv run --no-sync --with pytest --project . python -m pytest mlx_audio/tts/models/zonos2/tests/test_convert.py -q` → 12 passed.

Real-weight parity is the coordinator's Phase-D gate (no 8B weights / GPU here).