### PR TITLE
fix(tts/zonos2): speaker encoder = ECAPA-TDNN (not Qwen3)

### DIFF
--- a/mlx_audio/codec/models/ecapa_tdnn/config.py
+++ b/mlx_audio/codec/models/ecapa_tdnn/config.py
@@ -12,3 +12,8 @@ class EcapaTdnnConfig:
     res2net_scale: int = 8
     se_channels: int = 128
     global_context: bool = False
+    # Conv "same" padding mode for TDNN blocks. SpeechBrain ECAPA (LID/spark)
+    # uses zero padding; the Qwen3-TTS / ZONOS2 ECAPA checkpoint uses reflect
+    # padding (``padding="same", padding_mode="reflect"``). Only kernels > 1 are
+    # affected; the k=1 SE/ASP/fc convs are mode-independent.
+    conv_padding_mode: str = "zeros"

--- a/mlx_audio/codec/models/ecapa_tdnn/ecapa_tdnn.py
+++ b/mlx_audio/codec/models/ecapa_tdnn/ecapa_tdnn.py
@@ -4,6 +4,25 @@ import mlx.nn as nn
 from .config import EcapaTdnnConfig
 
 
+def _reflect_pad_time(x: mx.array, pad: int) -> mx.array:
+    """Reflect-pad an ``[B, L, C]`` tensor by ``pad`` frames on each side of L.
+
+    Matches ``torch.nn.functional.pad(..., mode="reflect")`` (the boundary frame
+    itself is excluded from the reflection), including its ``pad < L`` requirement:
+    a too-short input raises rather than silently under-padding (which would yield
+    a wrong-length, non-reflected tensor that diverges from torch without error).
+    """
+    if pad <= 0:
+        return x
+    if x.shape[1] <= pad:
+        raise ValueError(
+            f"sequence too short for reflect pad: length {x.shape[1]} <= pad {pad}"
+        )
+    left = x[:, 1 : pad + 1, :][:, ::-1, :]
+    right = x[:, -(pad + 1) : -1, :][:, ::-1, :]
+    return mx.concatenate([left, x, right], axis=1)
+
+
 class TDNNBlock(nn.Module):
     def __init__(
         self,
@@ -11,20 +30,31 @@ class TDNNBlock(nn.Module):
         out_channels: int,
         kernel_size: int,
         dilation: int = 1,
+        padding_mode: str = "zeros",
     ):
         super().__init__()
-        padding = (kernel_size - 1) * dilation // 2
+        if padding_mode not in ("zeros", "reflect"):
+            raise ValueError(
+                f"padding_mode must be 'zeros' or 'reflect', got {padding_mode!r}"
+            )
+        self.same_pad = (kernel_size - 1) * dilation // 2
+        self.padding_mode = padding_mode
+        # Reflect "same" padding is applied manually (MLX Conv1d only zero-pads),
+        # so the conv itself pads internally only in the default "zeros" mode.
+        conv_pad = 0 if padding_mode == "reflect" else self.same_pad
         self.conv = nn.Conv1d(
             in_channels,
             out_channels,
             kernel_size,
-            padding=padding,
+            padding=conv_pad,
             dilation=dilation,
             bias=True,
         )
         self.norm = nn.BatchNorm(out_channels)
 
     def __call__(self, x: mx.array) -> mx.array:
+        if self.padding_mode == "reflect":
+            x = _reflect_pad_time(x, self.same_pad)
         return self.norm(nn.relu(self.conv(x)))
 
 
@@ -35,6 +65,7 @@ class Res2NetBlock(nn.Module):
         kernel_size: int = 3,
         dilation: int = 1,
         scale: int = 8,
+        padding_mode: str = "zeros",
     ):
         super().__init__()
         if channels % scale != 0:
@@ -44,7 +75,8 @@ class Res2NetBlock(nn.Module):
         self.scale = scale
         hidden = channels // scale
         self.blocks = [
-            TDNNBlock(hidden, hidden, kernel_size, dilation) for _ in range(scale - 1)
+            TDNNBlock(hidden, hidden, kernel_size, dilation, padding_mode)
+            for _ in range(scale - 1)
         ]
 
     def __call__(self, x: mx.array) -> mx.array:
@@ -77,13 +109,14 @@ class SERes2NetBlock(nn.Module):
         dilation: int = 1,
         res2net_scale: int = 8,
         se_channels: int = 128,
+        padding_mode: str = "zeros",
     ):
         super().__init__()
-        self.tdnn1 = TDNNBlock(channels, channels, 1)
+        self.tdnn1 = TDNNBlock(channels, channels, 1, padding_mode=padding_mode)
         self.res2net_block = Res2NetBlock(
-            channels, kernel_size, dilation, res2net_scale
+            channels, kernel_size, dilation, res2net_scale, padding_mode
         )
-        self.tdnn2 = TDNNBlock(channels, channels, 1)
+        self.tdnn2 = TDNNBlock(channels, channels, 1, padding_mode=padding_mode)
         self.se_block = SEBlock(channels, se_channels)
 
     def __call__(self, x: mx.array) -> mx.array:
@@ -100,11 +133,12 @@ class AttentiveStatisticsPooling(nn.Module):
         channels: int,
         attention_channels: int = 128,
         global_context: bool = False,
+        padding_mode: str = "zeros",
     ):
         super().__init__()
         self.global_context = global_context
         tdnn_in = channels * 3 if global_context else channels
-        self.tdnn = TDNNBlock(tdnn_in, attention_channels, 1)
+        self.tdnn = TDNNBlock(tdnn_in, attention_channels, 1, padding_mode=padding_mode)
         self.conv = nn.Conv1d(attention_channels, channels, 1)
 
     def __call__(self, x: mx.array) -> mx.array:
@@ -134,14 +168,18 @@ class EcapaTdnnBackbone(nn.Module):
     def __init__(self, config: EcapaTdnnConfig):
         super().__init__()
         ch = config.channels
+        pm = config.conv_padding_mode
 
-        self.block0 = TDNNBlock(config.input_size, ch, config.kernel_sizes[0])
+        self.block0 = TDNNBlock(
+            config.input_size, ch, config.kernel_sizes[0], padding_mode=pm
+        )
         self.block1 = SERes2NetBlock(
             ch,
             config.kernel_sizes[1],
             config.dilations[1],
             config.res2net_scale,
             config.se_channels,
+            pm,
         )
         self.block2 = SERes2NetBlock(
             ch,
@@ -149,6 +187,7 @@ class EcapaTdnnBackbone(nn.Module):
             config.dilations[2],
             config.res2net_scale,
             config.se_channels,
+            pm,
         )
         self.block3 = SERes2NetBlock(
             ch,
@@ -156,14 +195,16 @@ class EcapaTdnnBackbone(nn.Module):
             config.dilations[3],
             config.res2net_scale,
             config.se_channels,
+            pm,
         )
         self.blocks = [self.block1, self.block2, self.block3]
 
-        self.mfa = TDNNBlock(ch * 3, ch * 3, config.kernel_sizes[4])
+        self.mfa = TDNNBlock(ch * 3, ch * 3, config.kernel_sizes[4], padding_mode=pm)
         self.asp = AttentiveStatisticsPooling(
             ch * 3,
             config.attention_channels,
             config.global_context,
+            pm,
         )
         self.asp_bn = nn.BatchNorm(ch * 6)
         self.fc = nn.Conv1d(ch * 6, config.embed_dim, 1)

--- a/mlx_audio/tts/models/zonos2/convert.py
+++ b/mlx_audio/tts/models/zonos2/convert.py
@@ -305,39 +305,223 @@ def convert(pth_path: str | Path, out_dir: str | Path, dtype: str = "bfloat16") 
     return out_dir
 
 
-# ── Qwen3 voice embedder conversion ───────────────────────────────────────────
+# ── ECAPA-TDNN voice embedder conversion ──────────────────────────────────────
+#
+# Despite the HF repo name "Qwen3-Voice-Embedding-12Hz-1.7B", the shipped
+# checkpoint is an ECAPA-TDNN x-vector speaker encoder (config.json:
+# ``architectures: ["EcapaTdnnSpeakerEncoder"]``, ``mel_dim=128`` -> ``enc_dim=2048``).
+# We remap its plain Conv1d state-dict onto the shared MLX ``EcapaTdnnBackbone``
+# (mlx_audio.codec.models.ecapa_tdnn).
+#
+# Key remap (HF reference layout -> MLX EcapaTdnnBackbone layout):
+#   blocks.0.conv.{weight,bias}        -> block0.conv.{weight,bias}
+#   blocks.{1,2,3}.<rest>              -> block{1,2,3}.<rest>   (tdnn1/tdnn2/
+#                                         res2net_block.blocks.N/se_block.conv1|2)
+#   mfa.conv.{weight,bias}             -> mfa.conv.{weight,bias}
+#   asp.tdnn.conv.* / asp.conv.*       -> asp.tdnn.conv.* / asp.conv.*
+#   fc.{weight,bias}                   -> fc.{weight,bias}
+# Conv1d weights are torch ``[out, in, k]`` -> MLX ``[out, k, in]`` (transpose
+# axes 0,2,1). The HF checkpoint has NO BatchNorm; the shared backbone carries BN
+# layers, which we fill with identity stats (running_mean=0, running_var=1,
+# weight=1, bias=0) so they reduce to a uniform, cosine-invariant scale.
+
+_ECAPA_VOICE_REPO = "marksverdhei/Qwen3-Voice-Embedding-12Hz-1.7B"
+
+# Norms / scale-and-bias tensors stay fp32 for numerical parity; convs cast.
+_ECAPA_FP32_SUBSTRINGS = ("norm", "running_mean", "running_var", "asp_bn")
+
+
+def _transpose_conv1d_weight(value: mx.array) -> mx.array:
+    """torch Conv1d weight ``[out, in, k]`` -> MLX Conv1d weight ``[out, k, in]``."""
+    if value.ndim != 3:
+        raise ValueError(f"Expected rank-3 Conv1d weight, got shape {value.shape}")
+    return value.transpose(0, 2, 1)
+
+
+def _remap_ecapa_key(key: str) -> str:
+    """Map a HF ``EcapaTdnnSpeakerEncoder`` key to the MLX ``EcapaTdnnBackbone`` key."""
+    for i in range(4):
+        prefix = f"blocks.{i}."
+        if key.startswith(prefix):
+            return f"block{i}." + key[len(prefix) :]
+    return key
+
+
+def remap_ecapa_state_dict(
+    weights: Dict[str, mx.array],
+    backbone_params: Dict[str, mx.array],
+    weight_dtype: mx.Dtype,
+) -> Dict[str, mx.array]:
+    """Remap a HF ECAPA state-dict onto the MLX ``EcapaTdnnBackbone`` layout.
+
+    Pure MLX (torch-free, unit-testable). ``backbone_params`` is the flat
+    ``{key: array}`` parameter tree of a freshly-built ``EcapaTdnnBackbone`` and is
+    the single source of truth for the expected key set: every conv key is filled
+    from the (transposed) HF tensor and every remaining (BatchNorm) key is filled
+    with identity stats.
+
+    The shared backbone registers the SE-Res2Net blocks twice — as
+    ``block{1,2,3}`` attributes and as a ``self.blocks`` list (``blocks.{0,1,2}``)
+    that aliases the same arrays. The HF checkpoint only carries one family
+    (``blocks.{1,2,3}``), so the list-alias keys are resolved from their matched
+    ``block{i}`` counterparts after the conv pass.
+
+    Raises:
+        ValueError: if a remapped conv key is unknown, a shape mismatches, or a
+            target key is left unfilled (so a silent drop is loud).
+    """
+    expected = set(backbone_params)
+    remapped: Dict[str, mx.array] = {}
+
+    for key, value in weights.items():
+        if "num_batches_tracked" in key:
+            continue
+        target = _remap_ecapa_key(key)
+        if target.endswith(".weight") and value.ndim == 3:
+            value = _transpose_conv1d_weight(value)
+        if target not in expected:
+            raise ValueError(f"Remapped key {key!r} -> {target!r} not in backbone")
+        if tuple(value.shape) != tuple(backbone_params[target].shape):
+            raise ValueError(
+                f"Shape mismatch for {target!r}: checkpoint {tuple(value.shape)} "
+                f"vs backbone {tuple(backbone_params[target].shape)}"
+            )
+        remapped[target] = value
+
+    for key, ref in backbone_params.items():
+        if key in remapped:
+            continue
+        if _is_batchnorm_param(key):
+            # BatchNorm is absent from the checkpoint -> identity (a uniform,
+            # cosine-invariant scale): running_mean/bias = 0, running_var/weight = 1.
+            leaf = key.rsplit(".", 1)[-1]
+            remapped[key] = (
+                mx.zeros(ref.shape)
+                if leaf in ("running_mean", "bias")
+                else mx.ones(ref.shape)
+            )
+            continue
+        alias = _blocks_list_alias(key)
+        if alias is not None and alias in remapped:
+            # ``blocks.{i}.X`` list-alias of an already-matched ``block{i+1}.X``.
+            remapped[key] = remapped[alias]
+            continue
+        raise ValueError(f"Unfilled backbone key {key!r}")
+
+    return {
+        k: v.astype(_ecapa_target_dtype(k, weight_dtype)) for k, v in remapped.items()
+    }
+
+
+def _is_batchnorm_param(key: str) -> bool:
+    """True for an ``EcapaTdnnBackbone`` BatchNorm parameter key.
+
+    BatchNorm params live under a ``.norm.`` submodule (``...norm.weight`` etc.) or
+    the top-level ``asp_bn`` module — never under a ``.conv.`` submodule.
+    """
+    parts = key.split(".")
+    if len(parts) < 2:
+        return False
+    parent = parts[-2]
+    return parent == "norm" or parts[0] == "asp_bn"
+
+
+def _blocks_list_alias(key: str) -> str | None:
+    """Map a ``blocks.{i}.X`` list-alias key to its ``block{i+1}.X`` counterpart.
+
+    The shared backbone exposes the SE-Res2Net blocks both as ``block{1,2,3}``
+    attributes and a ``self.blocks`` list (``blocks.{0,1,2}``) over the same
+    objects. Returns ``None`` for non-list keys (incl. the ``blocks.N.`` keys that
+    are part of a ``res2net_block``).
+    """
+    parts = key.split(".")
+    if len(parts) >= 2 and parts[0] == "blocks" and parts[1].isdigit():
+        return f"block{int(parts[1]) + 1}." + ".".join(parts[2:])
+    return None
+
+
+def _ecapa_target_dtype(key: str, weight_dtype: mx.Dtype) -> mx.Dtype:
+    """BatchNorm stats / norms stay fp32; conv weights and biases cast."""
+    if any(sub in key for sub in _ECAPA_FP32_SUBSTRINGS):
+        return mx.float32
+    return weight_dtype
+
+
+def _flat_params(module) -> Dict[str, mx.array]:
+    """Flatten an ``nn.Module`` parameter tree to ``{"a.b.c": array}``."""
+    from mlx.utils import tree_flatten
+
+    return dict(tree_flatten(module.parameters()))
 
 
 def convert_voice_embedder(
-    hf_repo: str = "marksverdhei/Qwen3-Voice-Embedding-12Hz-1.7B",
+    hf_repo: str = _ECAPA_VOICE_REPO,
     out_dir: str | Path = "./models/zonos2-voice-embedder-mlx",
     dtype: str = "bfloat16",
 ) -> Path:
-    """Convert the Qwen3-1.7B voice-embedder backbone (HF -> MLX safetensors).
+    """Convert the ECAPA-TDNN voice embedder (HF -> MLX ``EcapaTdnnBackbone``).
 
-    The mlx-audio ``qwen3`` model reuses ``mlx_lm.models.qwen3`` (``Model`` /
-    ``ModelArgs``), so the HF -> MLX conversion is exactly the standard mlx_lm
-    qwen3 path (sanitize = drop tied ``lm_head.weight``). This delegates to
-    ``mlx_lm.convert`` rather than re-implementing the qwen3 sanitize logic.
-
-    NOTE: the voice embedder uses the qwen3 backbone hidden states (2048-D) as a
-    speaker embedding; the embedding-head / mel-frontend wiring is finalized by
-    the coordinator in ``speaker_encoder.py`` (CONTRACT.md §5). This produces the
-    plain MLX-format qwen3 weights that the embedder loads.
+    The HF repo (misleadingly named "Qwen3-Voice-Embedding") ships an
+    ``EcapaTdnnSpeakerEncoder``; this loads its ``model.safetensors``, remaps the
+    Conv1d state-dict onto the shared MLX backbone, writes ``model.safetensors``,
+    and copies the checkpoint ``config.json`` / ``preprocessor_config.json``.
 
     Args:
-        hf_repo: HuggingFace repo id for the voice-embedding Qwen3 backbone.
+        hf_repo: HuggingFace repo id (or a local directory) for the ECAPA encoder.
         out_dir: output directory for the MLX model.
-        dtype: target weight dtype.
+        dtype: target weight dtype (norms/BatchNorm stats are always fp32).
 
     Returns:
         The output directory as a ``Path``.
     """
-    from mlx_lm import convert as mlx_lm_convert
+    if dtype not in _DTYPE_MAP:
+        raise ValueError(
+            f"Unsupported dtype {dtype!r}; choose one of {list(_DTYPE_MAP)}"
+        )
+    weight_dtype = _DTYPE_MAP[dtype]
+
+    from mlx_audio.codec.models.ecapa_tdnn import EcapaTdnnBackbone
+    from mlx_audio.tts.models.zonos2.config import ZONOS2Config
+    from mlx_audio.tts.models.zonos2.speaker_encoder import ecapa_config_from_zonos2
+
+    src_dir = Path(hf_repo)
+    if not src_dir.is_dir():
+        from huggingface_hub import snapshot_download
+
+        src_dir = Path(
+            snapshot_download(
+                hf_repo,
+                allow_patterns=[
+                    "model.safetensors",
+                    "config.json",
+                    "preprocessor_config.json",
+                ],
+            )
+        )
+
+    print(f"Converting ECAPA voice embedder {hf_repo} → {out_dir} (dtype={dtype})…")
+    weights = mx.load(str(src_dir / "model.safetensors"))
+    print(f"  {len(weights)} checkpoint tensors")
+
+    # Build the target backbone (same ECAPA config the embedder uses) to derive
+    # the expected conv + BatchNorm key set; the mel frontend is not needed here.
+    backbone = EcapaTdnnBackbone(ecapa_config_from_zonos2(ZONOS2Config()))
+    backbone_params = _flat_params(backbone)
+
+    remapped = remap_ecapa_state_dict(weights, backbone_params, weight_dtype)
 
     out_dir = Path(out_dir)
-    print(f"Converting voice embedder {hf_repo} → {out_dir} (dtype={dtype})…")
-    mlx_lm_convert(hf_repo, str(out_dir), dtype=dtype)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "model.safetensors"
+    mx.save_safetensors(str(out_path), remapped)
+    size_mb = out_path.stat().st_size / 1e6
+    print(f"  saved {out_path.name} ({size_mb:.0f} MB, {len(remapped)} tensors)")
+
+    for cfg_name in ("config.json", "preprocessor_config.json"):
+        src_cfg = src_dir / cfg_name
+        if src_cfg.exists():
+            (out_dir / cfg_name).write_bytes(src_cfg.read_bytes())
+
     print(f"Done → {out_dir}")
     return out_dir
 

--- a/mlx_audio/tts/models/zonos2/speaker_encoder.py
+++ b/mlx_audio/tts/models/zonos2/speaker_encoder.py
@@ -1,43 +1,47 @@
-"""ZONOS2 voice (speaker) encoder: ref-wav -> 2048-D speaker features.
+"""ZONOS2 voice (speaker) encoder: ref-wav -> 2048-D x-vector speaker embedding.
 
-Mirrors the upstream ``zonos2.models.speaker_cloning.Qwen3SpeakerEmbedding``
-preprocessing (``_make_mel`` / ``mel_transform``) and wraps a Qwen3 transformer
-backbone that consumes the log-mel features and returns a per-frame hidden state
-of width ``2048`` (the ``last_hidden_state`` the conditioning stack expects).
+The HF checkpoint ``marksverdhei/Qwen3-Voice-Embedding-12Hz-1.7B`` referenced by
+the upstream loader is — despite its name — an **ECAPA-TDNN x-vector speaker
+encoder**, not a Qwen3 transformer. Its on-disk ``config.json`` declares
+``architectures: ["EcapaTdnnSpeakerEncoder"]`` / ``model_type:
+"ecapa_tdnn_speaker_encoder"`` with ``mel_dim=128`` -> ``enc_dim=2048`` and the
+weight tensors are plain ``Conv1d`` blocks (``blocks.*``, ``mfa``, ``asp``,
+``fc``) with no transformer / no BatchNorm. The module name is the source of the
+"Qwen3" misnomer; the shipped architecture is the ground truth.
 
-Upstream reference (ground truth):
-  ``python/zonos2/models/speaker_cloning.py`` -> ``Qwen3SpeakerEmbedding`` which
-  builds the mel with ``torchaudio.transforms.MelSpectrogram(sample_rate=24000,
-  n_fft=1024, win_length=1024, hop_length=256, n_mels=128, f_min=0, f_max=12000,
-  power=1.0, center=False, norm="slaney", mel_scale="slaney")``, reflect-pads the
-  waveform by ``(n_fft - hop_length)//2`` on each side, then
-  ``log(clamp(mel, min=1e-5))`` and transposes to ``[B, frames, 128]``.
+This module therefore wires the (unchanged) log-mel ``VoiceMelFrontend`` into the
+shared MLX ``EcapaTdnnBackbone`` (``mlx_audio.codec.models.ecapa_tdnn``) and
+returns a *pooled* utterance-level x-vector ``[B, 2048]`` (NOT a per-frame
+sequence). The class is still named ``Qwen3VoiceEmbedding`` for API stability.
 
-IMPORTANT discrepancy (documented for the Phase-D coordinator):
-  The HF repo ``marksverdhei/Qwen3-Voice-Embedding-12Hz-1.7B`` referenced by the
-  upstream loader is, by its on-disk ``config.json`` / ``modeling_ecapa_tdnn.py``,
-  an **ECAPA-TDNN** x-vector encoder (``architectures: ["EcapaTdnnSpeakerEncoder"]``,
-  ``mel_dim=128`` -> ``enc_dim=2048``) whose ``last_hidden_state`` is a *pooled*
-  ``[B, 2048]`` vector, not a per-frame ``[B, frames, 2048]`` sequence. The repo name
-  ("Qwen3 ... 1.7B") does not match the shipped architecture. This module follows
-  the ZONOS2 ``CONTRACT.md`` API (Qwen3 backbone -> ``[B, frames, 2048]``); whether
-  the integration ultimately loads the ECAPA-TDNN checkpoint or a true Qwen3
-  backbone is a Phase-D wiring decision. The mel frontend here is identical for
-  both (the ECAPA feature extractor uses the exact same parameters).
+Frontend reference (ground truth), matching the checkpoint's
+``feature_extraction_ecapa_tdnn.py`` exactly:
+  reflect-pad the waveform by ``(n_fft - hop_length)//2`` on both sides, STFT with
+  a periodic Hann window (``win_length = n_fft``, ``center=False``), magnitude
+  spectrum projected through a slaney mel filterbank (slaney norm + slaney mel
+  scale), ``log(clamp(mel, min=1e-5))``, transposed to ``[B, frames, 128]``.
+  SR 24000, n_fft 1024, hop 256, n_mels 128, fmin 0, fmax 12000.
+
+Backbone reference (ground truth): the checkpoint's ``modeling_ecapa_tdnn.py``
+``EcapaTdnnSpeakerEncoder.forward(input_values=mel)`` — block0 (TDNN) + 3
+SE-Res2Net blocks + MFA + attentive-statistics pooling + a final ``fc`` conv ->
+``[B, enc_dim]``. There is no BatchNorm in the checkpoint; the shared
+``EcapaTdnnBackbone`` carries BatchNorm layers which the weight converter
+neutralises to identity (a uniform, cosine-invariant scale), so the reused module
+reproduces the checkpoint to high fidelity.
 """
 
 from __future__ import annotations
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx_lm.models.qwen3 import ModelArgs as Qwen3ModelArgs
-from mlx_lm.models.qwen3 import Qwen3Model
 
+from mlx_audio.codec.models.ecapa_tdnn import EcapaTdnnBackbone, EcapaTdnnConfig
 from mlx_audio.dsp import hanning, mel_filters, stft
 
 from .config import ZONOS2Config
 
-# Frontend constants — mirror Qwen3SpeakerEmbedding / EcapaTdnnFeatureExtractor.
+# Frontend constants — mirror EcapaTdnnFeatureExtractor / Qwen3SpeakerEmbedding.
 _TARGET_SAMPLE_RATE = 24_000
 _N_FFT = 1024
 _HOP_LENGTH = 256
@@ -46,6 +50,18 @@ _N_MELS = 128
 _F_MIN = 0.0
 _F_MAX = 12_000.0
 _LOG_CLAMP_MIN = 1e-5
+
+# ECAPA-TDNN encoder geometry (checkpoint config.json: enc_* fields).
+# enc_channels = [512, 512, 512, 512, 1536]: block0 (512) + 3 SE-Res2Net blocks
+# (512 each) feed the MFA over their concatenation (3*512 = 1536). The shared
+# EcapaTdnnBackbone derives mfa/asp/fc widths from ``channels`` (= 512 here); the
+# embed_dim (checkpoint enc_dim 2048) is taken from config.speaker_embedding_dim.
+_ENC_CHANNELS = 512
+_ENC_KERNEL_SIZES = [5, 3, 3, 3, 1]
+_ENC_DILATIONS = [1, 2, 3, 4, 1]
+_ENC_RES2NET_SCALE = 8
+_ENC_SE_CHANNELS = 128
+_ENC_ATTENTION_CHANNELS = 128
 
 
 def _reflect_pad_1d(x: mx.array, pad: int) -> mx.array:
@@ -68,7 +84,7 @@ def _reflect_pad_1d(x: mx.array, pad: int) -> mx.array:
 
 
 class VoiceMelFrontend(nn.Module):
-    """Log-mel frontend matching ``Qwen3SpeakerEmbedding._make_mel``.
+    """Log-mel frontend matching ``EcapaTdnnFeatureExtractor._compute_mel``.
 
     Produces ``[B, frames, 128]`` magnitude log-mel features:
       * reflect-pad the waveform by ``(n_fft - hop_length)//2`` on both sides;
@@ -148,34 +164,38 @@ def _resample_linear(wav: mx.array, orig_sr: int, target_sr: int) -> mx.array:
     return wav[left] * (1.0 - frac) + wav[right] * frac
 
 
-def _qwen3_args_from_config(config: ZONOS2Config) -> Qwen3ModelArgs:
-    """Build Qwen3 backbone args sized to the ZONOS2 speaker-embedding width."""
-    return Qwen3ModelArgs(
-        model_type="qwen3",
-        hidden_size=config.speaker_embedding_dim,
-        num_hidden_layers=config.n_layers,
-        intermediate_size=config.intermediate_size,
-        num_attention_heads=config.num_qo_heads,
-        rms_norm_eps=config.norm_eps,
-        # vocab_size is only used for the (unused) token embedding table; keep small.
-        vocab_size=1,
-        num_key_value_heads=config.n_kv_heads,
-        max_position_embeddings=config.max_seqlen,
-        rope_theta=config.rope_theta,
-        head_dim=config.head_dim,
-        tie_word_embeddings=True,
+def ecapa_config_from_zonos2(config: ZONOS2Config) -> EcapaTdnnConfig:
+    """Build the shared ``EcapaTdnnConfig`` for the ZONOS2 speaker encoder.
+
+    The widths come from the checkpoint's ``config.json`` (``enc_*`` fields). The
+    embedding width tracks ``config.speaker_embedding_dim`` (2048 for the released
+    checkpoint) so the pooled x-vector matches the conditioning-stack contract.
+    ``global_context=True`` because the reference ASP always concatenates
+    ``[x, mean, std]`` before the attention TDNN. ``conv_padding_mode="reflect"``
+    matches the checkpoint's ``padding="same", padding_mode="reflect"`` convs
+    (without it the conv edge frames diverge: cosine ~0.988 vs ~1.000).
+    """
+    return EcapaTdnnConfig(
+        input_size=_N_MELS,
+        channels=_ENC_CHANNELS,
+        embed_dim=config.speaker_embedding_dim,
+        kernel_sizes=list(_ENC_KERNEL_SIZES),
+        dilations=list(_ENC_DILATIONS),
+        attention_channels=_ENC_ATTENTION_CHANNELS,
+        res2net_scale=_ENC_RES2NET_SCALE,
+        se_channels=_ENC_SE_CHANNELS,
+        global_context=True,
+        conv_padding_mode="reflect",
     )
 
 
 class Qwen3VoiceEmbedding(nn.Module):
-    """Mel frontend + Qwen3 backbone -> per-frame ``[1, frames, 2048]`` features.
+    """Mel frontend + ECAPA-TDNN backbone -> pooled ``[B, 2048]`` x-vector.
 
-    The backbone consumes the ``[1, frames, n_mels]`` log-mel via an input
-    projection (``n_mels`` -> ``hidden``) fed as ``input_embeddings`` so the
-    Qwen3 transformer runs over the mel frames, returning ``last_hidden_state``
-    ``[1, frames, hidden]`` (``hidden == speaker_embedding_dim``, 2048 for the
-    1.7B config). One reference clip per call. See the module docstring for the
-    upstream-checkpoint caveat.
+    Despite the legacy class name (kept for API stability — the HF repo is named
+    "Qwen3-Voice-Embedding"), the backbone is an ECAPA-TDNN speaker encoder, the
+    architecture actually shipped in the checkpoint. ``__call__`` returns a single
+    utterance-level speaker embedding per reference clip, NOT a per-frame sequence.
     """
 
     def __init__(self, config: ZONOS2Config) -> None:
@@ -183,33 +203,24 @@ class Qwen3VoiceEmbedding(nn.Module):
         self.config = config
         self.target_sample_rate = _TARGET_SAMPLE_RATE
         self.frontend = VoiceMelFrontend(config)
-        args = _qwen3_args_from_config(config)
-        self.hidden_size = args.hidden_size
-        # mel (128) -> hidden projection feeding the transformer as input_embeddings.
-        self.mel_proj = nn.Linear(_N_MELS, args.hidden_size, bias=False)
-        self.backbone = Qwen3Model(args)
+        self.embed_dim = config.speaker_embedding_dim
+        self.backbone = EcapaTdnnBackbone(ecapa_config_from_zonos2(config))
 
     def __call__(self, wav: mx.array, sample_rate: int) -> mx.array:
-        """Reference waveform -> ``[1, frames, hidden]`` speaker features.
+        """Reference waveform -> pooled ``[B, embed_dim]`` x-vector.
 
         Matches upstream ``Qwen3SpeakerEmbedding.prepare_input`` semantics: a 2-D
         input is a single multi-channel clip ``[C, T]`` and is downmixed to mono
         by averaging channels (NOT a batch of clips). One reference clip in, one
-        ``[1, frames, hidden]`` feature sequence out.
+        ``[1, embed_dim]`` speaker embedding out.
 
         Args:
             wav: ``[T]`` mono or ``[C, T]`` multi-channel waveform.
             sample_rate: Sample rate of ``wav``; resampled to 24 kHz if different.
         """
         wav = self._prepare_input(wav, sample_rate)
-        mel = self.frontend(wav)
-        h = self.mel_proj(mel)
-        # NOTE: Qwen3Model applies a causal attention mask over the mel frames, so
-        # frame t only attends to <= t. A bidirectional pass is closer to a true
-        # utterance-level speaker encoder; reconciling the backbone choice (and the
-        # ECAPA-TDNN checkpoint discrepancy noted in the module docstring) is a
-        # Phase-D coordinator decision.
-        return self.backbone(None, cache=None, input_embeddings=h)
+        mel = self.frontend(wav)  # [1, frames, n_mels]
+        return self.backbone(mel)  # [1, embed_dim]
 
     def _prepare_input(self, wav: mx.array, sample_rate: int) -> mx.array:
         """Downmix to mono, resample to 24 kHz, return batched ``[1, T]``."""

--- a/mlx_audio/tts/models/zonos2/tests/test_convert.py
+++ b/mlx_audio/tts/models/zonos2/tests/test_convert.py
@@ -15,8 +15,10 @@ import numpy as np
 from mlx_audio.tts.models.zonos2 import convert as convert_mod
 from mlx_audio.tts.models.zonos2.convert import (
     SWITCH_MLP_PREFIX,
+    _flat_params,
     _torch_state_dict_to_mx,
     convert,
+    remap_ecapa_state_dict,
     remap_state_dict,
     split_sonic_w13,
 )
@@ -318,3 +320,145 @@ def test_remap_raises_on_target_key_collision():
     }
     with pytest.raises(ValueError):
         remap_state_dict(weights, mx.bfloat16)
+
+
+# ── ECAPA-TDNN voice-embedder remap ───────────────────────────────────────────
+
+
+def _ecapa_backbone_params() -> dict[str, mx.array]:
+    """Flat param tree of the real ZONOS2 ECAPA backbone (the expected key set)."""
+    from mlx_audio.tts.models.zonos2.config import ZONOS2Config
+    from mlx_audio.tts.models.zonos2.speaker_encoder import Qwen3VoiceEmbedding
+
+    return _flat_params(Qwen3VoiceEmbedding(ZONOS2Config()).backbone)
+
+
+def _fake_hf_ecapa_checkpoint(params: dict[str, mx.array]) -> dict[str, mx.array]:
+    """Build a synthetic HF (torch-layout) ECAPA state-dict from a backbone tree.
+
+    Mirrors the real checkpoint layout: conv-only keys (no BatchNorm), the
+    ``block{i}`` attribute family renamed to ``blocks.{i}`` (the ``self.blocks``
+    list-alias family is NOT a separate checkpoint family, so it is skipped), and
+    conv weights stored as torch ``[out, in, k]``.
+    """
+    parent = lambda k: k.split(".")[-2] if len(k.split(".")) >= 2 else ""
+    hf: dict[str, mx.array] = {}
+    for key, ref in params.items():
+        leaf = key.rsplit(".", 1)[-1]
+        # Skip BatchNorm params (checkpoint has none) and the blocks.N list alias.
+        if parent(key) == "norm" or key.startswith("asp_bn"):
+            continue
+        if key.split(".")[0] == "blocks":
+            continue
+        hf_key = key
+        for i in range(4):
+            if hf_key.startswith(f"block{i}."):
+                hf_key = f"blocks.{i}." + hf_key[len(f"block{i}.") :]
+                break
+        if leaf == "weight" and ref.ndim == 3:
+            # MLX [out, k, in] -> torch [out, in, k]
+            value = mx.random.normal((ref.shape[0], ref.shape[2], ref.shape[1]))
+        else:
+            value = mx.random.normal(ref.shape)
+        hf[hf_key] = value
+    return hf
+
+
+def test_remap_ecapa_maps_keys_and_transposes_convs():
+    params = _ecapa_backbone_params()
+    hf = _fake_hf_ecapa_checkpoint(params)
+
+    out = remap_ecapa_state_dict(hf, params, mx.float32)
+
+    # Every backbone key is present and correctly shaped.
+    assert set(out) == set(params)
+    for key, ref in params.items():
+        assert tuple(out[key].shape) == tuple(ref.shape)
+
+    # A conv weight is transposed torch [out, in, k] -> MLX [out, k, in] by VALUE,
+    # not merely reshaped (catches a wrong axis permutation that preserves shape).
+    src = hf["blocks.0.conv.weight"]  # block0 -> blocks.0 in HF layout
+    assert bool(mx.array_equal(out["block0.conv.weight"], src.transpose(0, 2, 1)))
+
+
+def test_remap_ecapa_resolves_blocks_list_alias_by_value():
+    params = _ecapa_backbone_params()
+    hf = _fake_hf_ecapa_checkpoint(params)
+
+    out = remap_ecapa_state_dict(hf, params, mx.float32)
+
+    # The backbone aliases block{1,2,3} as the self.blocks list (blocks.{0,1,2});
+    # the list-alias keys must carry the SAME values as their block{i+1} source.
+    alias_keys = [
+        k for k in params if k.split(".")[0] == "blocks" and k.split(".")[1].isdigit()
+    ]
+    assert alias_keys, "expected blocks.N list-alias keys in the shared backbone"
+    for alias in alias_keys:
+        parts = alias.split(".")
+        source = f"block{int(parts[1]) + 1}." + ".".join(parts[2:])
+        assert bool(mx.array_equal(out[alias], out[source])), alias
+
+
+def test_remap_ecapa_injects_identity_batchnorm():
+    params = _ecapa_backbone_params()
+    hf = _fake_hf_ecapa_checkpoint(params)
+
+    out = remap_ecapa_state_dict(hf, params, mx.float32)
+
+    # The checkpoint carries no BatchNorm; every BN param must be identity.
+    bn_keys = [k for k in params if ".norm." in k or k.startswith("asp_bn")]
+    assert bn_keys, "expected BatchNorm params in the shared backbone"
+    for key in bn_keys:
+        leaf = key.rsplit(".", 1)[-1]
+        arr = out[key]
+        if leaf in ("weight", "running_var"):
+            assert bool(mx.all(arr == 1.0)), key
+        else:  # bias / running_mean
+            assert bool(mx.all(arr == 0.0)), key
+
+
+def test_remap_ecapa_rejects_unknown_key():
+    import pytest
+
+    params = _ecapa_backbone_params()
+    hf = _fake_hf_ecapa_checkpoint(params)
+    hf["blocks.0.conv.bogus"] = mx.zeros((4,))
+
+    with pytest.raises(ValueError):
+        remap_ecapa_state_dict(hf, params, mx.float32)
+
+
+def test_remap_ecapa_rejects_shape_mismatch():
+    import pytest
+
+    params = _ecapa_backbone_params()
+    hf = _fake_hf_ecapa_checkpoint(params)
+    hf["blocks.0.conv.bias"] = mx.zeros((7,))  # wrong size
+
+    with pytest.raises(ValueError):
+        remap_ecapa_state_dict(hf, params, mx.float32)
+
+
+def test_remap_ecapa_rejects_missing_conv_weight():
+    import pytest
+
+    params = _ecapa_backbone_params()
+    hf = _fake_hf_ecapa_checkpoint(params)
+    # A genuine checkpoint conv tensor is absent -> the fill pass must raise loudly
+    # rather than silently leaving a random/identity conv (only BN keys may be
+    # back-filled, and conv keys have no list-alias source for block0).
+    del hf["blocks.0.conv.weight"]
+
+    with pytest.raises(ValueError):
+        remap_ecapa_state_dict(hf, params, mx.float32)
+
+
+def test_remap_ecapa_dtype_policy_norms_fp32():
+    params = _ecapa_backbone_params()
+    hf = _fake_hf_ecapa_checkpoint(params)
+
+    out = remap_ecapa_state_dict(hf, params, mx.bfloat16)
+
+    assert out["block0.conv.weight"].dtype == mx.bfloat16
+    assert out["block0.norm.running_mean"].dtype == mx.float32
+    assert out["asp_bn.running_var"].dtype == mx.float32

--- a/mlx_audio/tts/models/zonos2/tests/test_speaker_encoder.py
+++ b/mlx_audio/tts/models/zonos2/tests/test_speaker_encoder.py
@@ -1,9 +1,9 @@
-"""Synthetic shape/wiring tests for the ZONOS2 voice encoder.
+"""Synthetic shape/wiring tests for the ZONOS2 voice (speaker) encoder.
 
 No weights and no GPU: verifies that the log-mel frontend matches the upstream
-frame geometry and that the Qwen3-backbone wrapper threads mel features through
-to a per-frame hidden state of the configured width. Full numerical/CUDA parity
-is the Phase-D coordinator gate.
+frame geometry and that the ECAPA-TDNN backbone wrapper pools the mel features
+into a single utterance-level x-vector ``[B, embed_dim]``. Full numerical parity
+vs the real checkpoint is covered by ``parity_test/zonos2/check_ecapa.py``.
 """
 
 from __future__ import annotations
@@ -16,6 +16,7 @@ from mlx_audio.tts.models.zonos2.config import ZONOS2Config
 from mlx_audio.tts.models.zonos2.speaker_encoder import (
     Qwen3VoiceEmbedding,
     VoiceMelFrontend,
+    ecapa_config_from_zonos2,
 )
 
 _SAMPLE_RATE = 24_000
@@ -41,17 +42,17 @@ def _sine(num_samples: int, freq_hz: float = 220.0) -> mx.array:
     )
 
 
-def _tiny_config(hidden: int = 32) -> ZONOS2Config:
-    """A small backbone config for fast shape-flow testing."""
+def _tiny_config(embed_dim: int = 2048) -> ZONOS2Config:
+    """A small config for fast shape-flow testing (ECAPA geometry is fixed)."""
     return ZONOS2Config(
         n_layers=2,
-        dim=hidden,
+        dim=32,
         head_dim=8,
         n_heads=4,
         n_kv_heads=2,
-        speaker_embedding_dim=hidden,
+        speaker_embedding_dim=embed_dim,
         max_seqlen=4096,
-        moe_n_experts=1,  # disable MoE; backbone here is plain Qwen3
+        moe_n_experts=1,
     )
 
 
@@ -91,25 +92,37 @@ def test_mel_frontend_rejects_too_short_waveform():
     assert raised
 
 
-def test_voice_embedding_maps_mel_to_hidden_width():
-    hidden = 32
-    config = _tiny_config(hidden=hidden)
+def test_ecapa_config_matches_checkpoint_geometry():
+    """The derived ECAPA config must match the checkpoint's enc_* fields."""
+    cfg = ecapa_config_from_zonos2(_tiny_config(embed_dim=2048))
+    assert cfg.input_size == _N_MELS
+    assert cfg.channels == 512
+    assert cfg.embed_dim == 2048
+    assert cfg.kernel_sizes == [5, 3, 3, 3, 1]
+    assert cfg.dilations == [1, 2, 3, 4, 1]
+    assert cfg.res2net_scale == 8
+    assert cfg.se_channels == 128
+    assert cfg.attention_channels == 128
+    assert cfg.global_context is True
+
+
+def test_voice_embedding_pools_to_embed_dim():
+    embed_dim = 2048
+    config = _tiny_config(embed_dim=embed_dim)
     encoder = Qwen3VoiceEmbedding(config)
 
     wav = _sine(_SAMPLE_RATE)[None, :]  # [1, 24000] already at 24 kHz
     out = encoder(wav, sample_rate=_SAMPLE_RATE)
 
-    frames = _expected_frames(_SAMPLE_RATE)
-    assert out.shape == (1, frames, hidden)
+    # Pooled x-vector: one embedding per clip, NOT a per-frame sequence.
+    assert out.shape == (1, embed_dim)
     assert bool(mx.all(mx.isfinite(out)))
 
 
 def test_voice_embedding_resamples_non_target_rate():
-    hidden = 32
-    encoder = Qwen3VoiceEmbedding(_tiny_config(hidden=hidden))
+    embed_dim = 2048
+    encoder = Qwen3VoiceEmbedding(_tiny_config(embed_dim=embed_dim))
 
-    # Non-integer ratio (44.1 kHz -> 24 kHz) so the frame count is derived from the
-    # actual resampled length, not an integer multiple that can't fail.
     src_sr = 44_100
     n_in = src_sr  # 1 second
     wav = mx.array(
@@ -118,18 +131,28 @@ def test_voice_embedding_resamples_non_target_rate():
     )
     out = encoder(wav, sample_rate=src_sr)
 
+    assert out.shape == (1, embed_dim)
+    assert bool(mx.all(mx.isfinite(out)))
+
+    # The pooled output hides the frame count, so assert the resample stage itself
+    # actually changed the length (44.1 kHz -> 24 kHz) via the prepared waveform.
+    prepared = encoder._prepare_input(wav, src_sr)
     n_resampled = max(1, round(n_in * _SAMPLE_RATE / src_sr))
-    assert out.shape == (1, _expected_frames(n_resampled), hidden)
-    # The resampled length must differ from the source length (resample happened).
+    assert prepared.shape == (1, n_resampled)
     assert n_resampled != n_in
 
 
 def test_voice_embedding_downmixes_stereo():
-    hidden = 32
-    encoder = Qwen3VoiceEmbedding(_tiny_config(hidden=hidden))
+    embed_dim = 2048
+    encoder = Qwen3VoiceEmbedding(_tiny_config(embed_dim=embed_dim))
 
     mono = _sine(_SAMPLE_RATE)
     stereo = mx.stack([mono, mono], axis=0)  # [2, 24000]
     out = encoder(stereo, sample_rate=_SAMPLE_RATE)
 
-    assert out.shape == (1, _expected_frames(_SAMPLE_RATE), hidden)
+    assert out.shape == (1, embed_dim)
+    # Channel-averaging a duplicated stereo clip must equal the mono embedding
+    # (downmix is a mean over channels, NOT a batch of two clips).
+    mono_out = encoder(mono, sample_rate=_SAMPLE_RATE)
+    assert mono_out.shape == (1, embed_dim)
+    assert bool(mx.allclose(out, mono_out, atol=1e-4))

--- a/parity_test/zonos2/check_ecapa.py
+++ b/parity_test/zonos2/check_ecapa.py
@@ -1,0 +1,130 @@
+"""ECAPA-TDNN voice-encoder parity check: MLX port vs the real torch checkpoint.
+
+Loads the torch reference ``EcapaTdnnSpeakerEncoder`` (the architecture actually
+shipped in ``marksverdhei/Qwen3-Voice-Embedding-12Hz-1.7B``, despite the "Qwen3"
+name), converts the HF weights with ``convert_voice_embedder``, loads the MLX
+``EcapaTdnnBackbone``, feeds the SAME reference waveform through both, and reports
+cosine similarity + max abs diff between the two 2048-D x-vectors.
+
+Run (fully local / CPU / tiny model):
+    uv run --no-sync --with torch --with transformers --with torchaudio \
+        --project /Volumes/DATA/mlx-audio python parity_test/zonos2/check_ecapa.py
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+
+REPO = "marksverdhei/Qwen3-Voice-Embedding-12Hz-1.7B"
+_REF_WAV_CANDIDATES = [
+    "/Volumes/DATA/mlx-audio-zonos2/parity_test/zonos2/reference/item_0.wav",
+]
+_TARGET_SR = 24_000
+
+
+def _read_wav(path: str) -> tuple[np.ndarray, int]:
+    """Read a PCM WAV to mono float32 in [-1, 1] using the stdlib (no torchcodec)."""
+    import wave
+
+    with wave.open(path, "rb") as w:
+        sr = w.getframerate()
+        n_ch = w.getnchannels()
+        sampwidth = w.getsampwidth()
+        frames = w.readframes(w.getnframes())
+    if sampwidth != 2:
+        raise ValueError(f"only 16-bit PCM supported, got sampwidth={sampwidth}")
+    data = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+    if n_ch > 1:
+        data = data.reshape(-1, n_ch).mean(axis=1)
+    return data, sr
+
+
+def _load_waveform() -> np.ndarray:
+    """Return a fixed mono float32 24 kHz test waveform (reference wav or sine)."""
+    for cand in _REF_WAV_CANDIDATES:
+        if Path(cand).exists():
+            import torch
+            import torchaudio
+
+            wav_np, sr = _read_wav(cand)
+            wav = torch.from_numpy(wav_np)
+            if sr != _TARGET_SR:
+                wav = torchaudio.functional.resample(wav, sr, _TARGET_SR)
+            print(
+                f"  using reference wav: {cand} "
+                f"({wav.shape[0]} samples @ {_TARGET_SR} Hz)"
+            )
+            return wav.numpy().astype(np.float32)
+    # Fallback synthetic sine (3 s) — deterministic.
+    n = _TARGET_SR * 3
+    t = np.arange(n, dtype=np.float32) / _TARGET_SR
+    wav = 0.5 * np.sin(2 * np.pi * 220.0 * t).astype(np.float32)
+    print(f"  using synthetic sine ({n} samples @ {_TARGET_SR} Hz)")
+    return wav
+
+
+def _torch_reference(wav: np.ndarray) -> np.ndarray:
+    """Reference embedding [2048] from the HF torch model + its feature extractor."""
+    import torch
+    from transformers import AutoFeatureExtractor, AutoModel
+
+    model = AutoModel.from_pretrained(REPO, trust_remote_code=True).eval().to("cpu")
+    fe = AutoFeatureExtractor.from_pretrained(REPO, trust_remote_code=True)
+    feats = fe(wav, sampling_rate=_TARGET_SR, return_tensors="pt")
+    with torch.no_grad():
+        out = model(input_values=feats["input_values"].float())
+    emb = out.last_hidden_state.squeeze(0).float().numpy()
+    return emb
+
+
+def _mlx_port(wav: np.ndarray) -> np.ndarray:
+    """MLX embedding [2048]: convert HF weights, load backbone, run frontend."""
+    from mlx.utils import tree_unflatten
+
+    from mlx_audio.tts.models.zonos2.config import ZONOS2Config
+    from mlx_audio.tts.models.zonos2.convert import convert_voice_embedder
+    from mlx_audio.tts.models.zonos2.speaker_encoder import Qwen3VoiceEmbedding
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = convert_voice_embedder(REPO, tmp, dtype="float32")
+        weights = mx.load(str(Path(out_dir) / "model.safetensors"))
+
+        encoder = Qwen3VoiceEmbedding(ZONOS2Config())
+        encoder.backbone.update(tree_unflatten(list(weights.items())))
+        encoder.eval()
+        mx.eval(encoder.parameters())
+
+        emb = encoder(mx.array(wav), sample_rate=_TARGET_SR)
+        mx.eval(emb)
+    return np.array(emb.squeeze(0), dtype=np.float32)
+
+
+def main() -> None:
+    print("ECAPA-TDNN voice-encoder parity: MLX port vs torch reference")
+    wav = _load_waveform()
+
+    print("Running torch reference...")
+    ref = _torch_reference(wav)
+    print("Running MLX port...")
+    mlx_emb = _mlx_port(wav)
+
+    assert ref.shape == (2048,), f"reference shape {ref.shape}"
+    assert mlx_emb.shape == (2048,), f"mlx shape {mlx_emb.shape}"
+
+    cos = float(
+        np.dot(ref, mlx_emb) / (np.linalg.norm(ref) * np.linalg.norm(mlx_emb) + 1e-12)
+    )
+    maxabs = float(np.max(np.abs(ref - mlx_emb)))
+    print()
+    print(f"  reference norm = {np.linalg.norm(ref):.4f}")
+    print(f"  mlx       norm = {np.linalg.norm(mlx_emb):.4f}")
+    print(f"ECAPA: cosine={cos:.6f} maxabs={maxabs:.6e}")
+    print("PASS" if cos >= 0.999 else "FAIL (cosine < 0.999)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The ZONOS2 voice/speaker encoder was wired onto a **Qwen3 transformer** backbone, but the real checkpoint `marksverdhei/Qwen3-Voice-Embedding-12Hz-1.7B` is — despite its name — an **ECAPA-TDNN x-vector encoder**. Verified against its on-disk config, not the repo name:

- `config.json`: `"architectures":["EcapaTdnnSpeakerEncoder"]`, `"model_type":"ecapa_tdnn_speaker_encoder"`, `mel_dim=128 → enc_dim=2048`, `enc_channels=[512,512,512,512,1536]`, plain `Conv1d` blocks (`blocks.*`, `mfa`, `asp`, `fc`) with **no transformer and no BatchNorm**.

This switches the backend to ECAPA-TDNN, reusing mlx-audio's existing shared `EcapaTdnnBackbone`.

## Changes

- **`speaker_encoder.py`** — keep `VoiceMelFrontend` (its mel params already match the checkpoint's `EcapaTdnnFeatureExtractor` exactly); replace the Qwen3 backbone with the shared `EcapaTdnnBackbone` (`mlx_audio.codec.models.ecapa_tdnn`). `Qwen3VoiceEmbedding` (name kept for API stability) now returns a **pooled `[B, 2048]` x-vector**, not a per-frame sequence. `__call__(wav, sample_rate) -> [B, 2048]`.
- **`codec/models/ecapa_tdnn`** — add `conv_padding_mode` (`"zeros"` default | `"reflect"`) to `EcapaTdnnConfig` and thread it through `TDNNBlock`. The Qwen3-TTS ECAPA uses `padding="same", padding_mode="reflect"`; matching it is the **entire** offline-vs-reference delta (cosine 0.988 → 1.000). Default `"zeros"` keeps the SpeechBrain LID/spark callers byte-identical. Invalid mode now raises; reflect-pad now raises on too-short input (matches torch).
- **`convert.py`** — rewrite `convert_voice_embedder` as an ECAPA HF→MLX converter: remaps `blocks.N → blockN`, transposes Conv1d weights torch `[out,in,k]` → MLX `[out,k,in]`, injects identity BatchNorm (checkpoint has none → uniform, cosine-invariant scale), resolves the backbone's `block{1,2,3}`/`blocks.{0,1,2}` list alias, keeps norms fp32, writes `model.safetensors` + copies `config.json`/`preprocessor_config.json`. Pure remap is torch-free/unit-testable.
- **Tests** — assert pooled `[B,2048]` shape + ECAPA geometry, resample/downmix invariants; ECAPA converter tests (key map, conv transpose by value, alias value-equality, identity BN, dtype policy, missing/unknown/shape-mismatch raises). 177 green; LID (44) + ecapa backbone (26) regression suites unchanged.
- **`parity_test/zonos2/check_ecapa.py`** — fully-local CPU e2e gate: loads the torch reference `EcapaTdnnSpeakerEncoder`, converts via `convert_voice_embedder`, feeds the same reference waveform through both, reports cosine + max-abs-diff.

## Validation (e2e gate)

`ECAPA: cosine=1.000000 maxabs=1.46e-04` vs the torch reference on `parity_test/zonos2/reference/item_0.wav` (reference norm 17.2586 = MLX norm 17.2586).