### PR TITLE
fix(tts/zonos2): eos-flush + voice cloning

### DIFF
--- a/mlx_audio/tts/models/zonos2/tests/test_zonos2.py
+++ b/mlx_audio/tts/models/zonos2/tests/test_zonos2.py
@@ -208,6 +208,280 @@ def test_generate_codes_returns_eos_frame_when_requested():
     assert eos_frame is None or isinstance(eos_frame, int)
 
 
+def _force_eoa_at(model: Model, cfg: ZONOS2Config, eoa_step: int):
+    """Patch the backbone logits so codebook 0 argmaxes to ``eoa_id`` at one step.
+
+    Returns a closure to install as ``backbone.compute_logits`` that emits a normal
+    (argmax 0) frame everywhere except at generation step ``eoa_step``, where
+    codebook 0's argmax is forced to ``eoa_id`` — driving the delay-aware EOS
+    countdown exactly like a real end-of-audio sample.
+    """
+    audio_vocab = cfg.audio_vocab
+    n_cb = cfg.n_codebooks
+    state = {"step": 0}
+
+    def fake_logits(hidden: mx.array) -> mx.array:
+        # hidden is [1, 1, dim]; emit [1, 1, n_cb, audio_vocab].
+        logits = np.zeros((1, 1, n_cb, audio_vocab), dtype=np.float32)
+        if state["step"] == eoa_step:
+            logits[0, 0, 0, cfg.eoa_id] = 10.0  # cb0 -> EOA at this step
+        state["step"] += 1
+        return mx.array(logits)
+
+    return fake_logits, state
+
+
+def test_generate_codes_eos_flush_countdown_and_frame():
+    """Forced EOA at a known step yields the upstream-aligned eos_frame + tail flush.
+
+    Mirrors upstream ``TTSSequence._check_eos`` / ``TTSReq.check_eos``: when EOA is
+    sampled in codebook ``c`` at generation step ``s``, ``eos_frame = s - c`` and the
+    loop runs ``n_codebooks + 1`` more frames (the delay tail) before stopping.
+    """
+    # eoa/pad ids must fall inside the tiny audio vocab (codebook_size + 2).
+    cfg = _tiny_config(eoa_id=8, audio_pad_id=9)
+    model = Model(cfg)
+    prompt = _random_prompt(cfg, seq=5)
+
+    eoa_step = 4
+    fake_logits, _ = _force_eoa_at(model, cfg, eoa_step)
+    model.backbone.compute_logits = fake_logits  # type: ignore[assignment]
+
+    codes, eos_frame = model.generate_codes(
+        prompt,
+        max_frames=64,
+        temperature=0.0,
+        top_k=1,
+        stop_on_eoa=True,
+        return_eos_frame=True,
+    )
+    produced = np.asarray(codes)
+    # EOA in codebook 0 at step 4 -> aligned eos_frame == 4 - 0 == 4.
+    assert eos_frame == eoa_step
+    # Countdown = n_codebooks + 1 extra frames after detection; detection frame is
+    # included, so total == eoa_step + 1 (detection) + n_codebooks (remaining tail).
+    assert produced.shape[0] == eoa_step + 1 + cfg.n_codebooks
+    # The detection frame's codebook 0 carries the EOA id.
+    assert int(produced[eoa_step, 0]) == cfg.eoa_id
+
+
+def test_decode_audio_truncates_to_eos_frame():
+    """``decode_audio`` shears then slices ``[:eos_frame]`` before DAC (no tail leak)."""
+    cfg = _tiny_config()
+    model = Model(cfg)
+    # 12 raw frames; an eos_frame of 5 must keep exactly 5 sheared output rows.
+    raw = mx.array(
+        np.random.randint(0, cfg.codebook_size, (12, cfg.n_codebooks)).astype(np.int32)
+    )
+    sheared_full = np.asarray(Model.shear_up(raw, cfg.audio_pad_id))
+
+    captured = {}
+
+    def fake_from_codes(dac_codes):
+        captured["shape"] = tuple(dac_codes.shape)  # [1, C, H]
+        # Return a dummy latent; decode() is also stubbed below.
+        return (mx.zeros((1, 1, dac_codes.shape[-1])),)
+
+    class _DummyDac:
+        class quantizer:  # noqa: N801 - mimic the attribute path dac.quantizer
+            from_codes = staticmethod(fake_from_codes)
+
+        @staticmethod
+        def decode(z):
+            return mx.zeros((1, z.shape[-1]))
+
+    model._dac = _DummyDac()  # bypass the real DAC download
+
+    model.decode_audio(raw, eos_frame=5)
+    # DAC saw exactly eos_frame (=5) frames along the time axis.
+    assert captured["shape"] == (1, cfg.n_codebooks, 5)
+    # And the kept rows are the first 5 of the full sheared tensor.
+    assert sheared_full.shape[0] == 12
+
+
+def test_project_speaker_shape():
+    cfg = _tiny_config(
+        speaker_enabled=True, speaker_embedding_dim=48, speaker_lda_dim=24
+    )
+    model = Model(cfg)
+    assert model.backbone.speaker_lda_projection.weight.shape == (24, 48)
+    assert model.backbone.speaker_projection.weight.shape == (cfg.dim, 24)
+    emb = mx.random.normal((1, cfg.speaker_embedding_dim))
+    out = model.backbone.project_speaker(emb)
+    assert out.shape == (1, cfg.dim)
+
+
+def test_with_speaker_frames_prefix_layout():
+    cfg = _tiny_config(
+        speaker_enabled=True,
+        speaker_embedding_dim=48,
+        speaker_lda_dim=24,
+        speaker_background_token_enabled=True,
+        accurate_mode_token_enabled=True,
+        speaking_rate_num_buckets=2,
+        quality_buckets={"a": ("0-1", "1+"), "b": ("0-1", "1+")},
+    )
+    model = Model(cfg)
+    prompt = _random_prompt(cfg, seq=5)
+    new_prompt, pos = model.with_speaker_frames(prompt)
+    assert pos == 0
+    assert new_prompt.shape == (5 + 2, cfg.n_codebooks + 1)  # slot + bg marker
+    np_new = np.asarray(new_prompt)
+    pad = cfg.audio_pad_id
+    # Row 0: speaker slot (all audio_pad + text_vocab in the text column).
+    assert np.all(np_new[0, : cfg.n_codebooks] == pad)
+    assert int(np_new[0, cfg.n_codebooks]) == cfg.text_vocab
+    # Row 1: clean-background marker (audio_pad + clean-bg token).
+    assert np.all(np_new[1, : cfg.n_codebooks] == pad)
+    assert int(np_new[1, cfg.n_codebooks]) == model._clean_background_token()
+    # The rest is the original prompt verbatim.
+    assert np.array_equal(np_new[2:], np.asarray(prompt))
+
+
+def test_generate_codes_with_speaker_embedding_runs():
+    cfg = _tiny_config(
+        speaker_enabled=True, speaker_embedding_dim=48, speaker_lda_dim=24
+    )
+    model = Model(cfg)
+    prompt = _random_prompt(cfg, seq=6)
+    new_prompt, pos = model.with_speaker_frames(prompt)
+    emb = mx.random.normal((cfg.speaker_embedding_dim,))
+    codes = model.generate_codes(
+        new_prompt,
+        max_frames=4,
+        temperature=0.0,
+        top_k=1,
+        stop_on_eoa=False,
+        speaker_embedding=emb,
+        speaker_position=pos,
+    )
+    assert codes.shape == (4, cfg.n_codebooks)
+    assert codes.dtype == mx.int32
+
+
+def test_speaker_injection_changes_first_logits():
+    """Injecting a speaker embedding at position 0 perturbs the prefill hidden state."""
+    cfg = _tiny_config(
+        speaker_enabled=True, speaker_embedding_dim=48, speaker_lda_dim=24
+    )
+    model = Model(cfg)
+    prompt = _random_prompt(cfg, seq=5)[None]
+    proj = model.backbone.project_speaker(
+        mx.random.normal((1, cfg.speaker_embedding_dim))
+    )
+
+    base = model.backbone(prompt)
+    injected = model.backbone(prompt, speaker_emb=proj, speaker_pos=0)
+    # Replacing the position-0 embedding must change the output (not a no-op).
+    assert not bool(mx.allclose(base, injected))
+
+
+def test_trim_leading_silence_helper():
+    sr = 44100
+    wav = mx.array(
+        np.concatenate([np.zeros(2000, np.float32), (np.ones(1000, np.float32) * 0.4)])
+    )
+    trimmed = Model._trim_leading_silence(wav, threshold=0.01, keep_samples=128)
+    # Drops the leading 2000 silent samples minus the 128 kept as lead-in.
+    assert trimmed.shape[0] == 3000 - (2000 - 128)
+    # All-silent input is returned unchanged (nothing crosses the threshold).
+    silent = mx.zeros((500,))
+    assert Model._trim_leading_silence(silent).shape[0] == 500
+
+
+def test_speaker_projection_absent_without_speaker_config():
+    cfg = _tiny_config(speaker_enabled=False)
+    model = Model(cfg)
+    assert model.backbone.speaker_projection is None
+    assert model.backbone.speaker_lda_projection is None
+
+
+def _speaker_enabled_config(**ov) -> ZONOS2Config:
+    return _tiny_config(
+        speaker_enabled=True, speaker_embedding_dim=48, speaker_lda_dim=24, **ov
+    )
+
+
+def _ckpt_keys_no_prefix(model: Model) -> dict:
+    return {k[len("backbone.") :]: v for k, v in tree_flatten(model.parameters())}
+
+
+def test_base_checkpoint_loads_strict_via_speaker_backfill():
+    """A base checkpoint (no speaker keys) still loads strict (backfill keeps init)."""
+    cfg = _speaker_enabled_config()
+    src = Model(cfg)
+    base_ckpt = {
+        k: v
+        for k, v in _ckpt_keys_no_prefix(src).items()
+        if not k.startswith("speaker_")
+    }
+    assert not any("speaker" in k for k in base_ckpt)
+    dst = Model(cfg)
+    # Must NOT raise despite the model carrying speaker params absent from the ckpt.
+    dst.load_weights(list(base_ckpt.items()), strict=True)
+
+
+def test_strict_load_still_catches_missing_non_speaker_key():
+    """The speaker backfill must not mask a genuinely missing backbone key."""
+    cfg = _speaker_enabled_config()
+    src = Model(cfg)
+    ckpt = {
+        k: v
+        for k, v in _ckpt_keys_no_prefix(src).items()
+        if not k.startswith("speaker_")
+    }
+    drop = next(k for k in ckpt if "multi_output" in k)
+    del ckpt[drop]
+    dst = Model(cfg)
+    try:
+        dst.load_weights(list(ckpt.items()), strict=True)
+        raised = False
+    except Exception:
+        raised = True
+    assert raised, "a missing non-speaker key must still fail the strict load"
+
+
+def test_load_speaker_weights_validates_shape_and_completeness():
+    cfg = _speaker_enabled_config()
+    good = {
+        "speaker_lda_projection.weight": mx.zeros((24, 48)),
+        "speaker_lda_projection.bias": mx.zeros((24,)),
+        "speaker_projection.weight": mx.zeros((cfg.dim, 24)),
+        "speaker_projection.bias": mx.zeros((cfg.dim,)),
+    }
+    Model(cfg).load_speaker_weights(list(good.items()))  # OK
+
+    wrong = dict(good)
+    wrong["speaker_projection.weight"] = mx.zeros((cfg.dim, 99))  # bad in-dim
+    try:
+        Model(cfg).load_speaker_weights(list(wrong.items()))
+        bad_shape_raised = False
+    except ValueError:
+        bad_shape_raised = True
+    assert bad_shape_raised
+
+    incomplete = [(k, v) for k, v in good.items() if "bias" not in k]
+    try:
+        Model(cfg).load_speaker_weights(incomplete)
+        incomplete_raised = False
+    except ValueError:
+        incomplete_raised = True
+    assert incomplete_raised
+
+
+def test_speaker_injection_out_of_range_position_raises():
+    cfg = _speaker_enabled_config()
+    model = Model(cfg)
+    prompt = _random_prompt(cfg, seq=4)[None]
+    proj = model.backbone.project_speaker(mx.zeros((1, cfg.speaker_embedding_dim)))
+    try:
+        model.backbone(prompt, speaker_emb=proj, speaker_pos=99)
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised, "out-of-range speaker_pos must raise, not silently no-op"
+
+
 def test_load_weights_reconciles_convert_keys():
     """A synthetic checkpoint in convert.py's key layout loads strictly."""
     cfg = _tiny_config()

--- a/mlx_audio/tts/models/zonos2/zonos2.py
+++ b/mlx_audio/tts/models/zonos2/zonos2.py
@@ -43,6 +43,7 @@ from typing import List, Optional, Tuple, Union
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
+from mlx.utils import tree_flatten
 from mlx_lm.models.cache import KVCache
 
 from mlx_audio.tts.models.zonos2.config import ZONOS2Config
@@ -218,6 +219,25 @@ class Zonos2Backbone(nn.Module):
         self.emb_norm = RMSNormFused(
             config.dim, eps=config.norm_eps, elementwise_affine=False
         )
+
+        # Optional speaker-embedding projections (voice-cloning checkpoints only).
+        # ECAPA x-vector [speaker_embedding_dim] -> LDA -> [speaker_lda_dim] ->
+        # speaker_projection -> [dim]; injected (index-replace) at the speaker
+        # token position before emb_norm. Mirrors upstream Zonos2ForCausalLM.
+        if config.speaker_enabled and config.speaker_lda_dim:
+            self.speaker_lda_projection = nn.Linear(
+                config.speaker_embedding_dim, int(config.speaker_lda_dim), bias=True
+            )
+            speaker_proj_in = int(config.speaker_lda_dim)
+        else:
+            self.speaker_lda_projection = None
+            speaker_proj_in = config.speaker_embedding_dim
+        self.speaker_projection = (
+            nn.Linear(speaker_proj_in, config.dim, bias=True)
+            if config.speaker_enabled
+            else None
+        )
+
         self.layers = [
             TransformerBlock(config, layer_id) for layer_id in range(config.n_layers)
         ]
@@ -230,18 +250,57 @@ class Zonos2Backbone(nn.Module):
             config.dim, self.audio_vocab * self.n_codebooks
         )
 
+    def project_speaker(self, speaker_emb: mx.array) -> mx.array:
+        """ECAPA x-vector ``[..., speaker_embedding_dim]`` -> backbone dim ``[..., dim]``.
+
+        Applies the (optional) LDA projection then the speaker projection, exactly
+        mirroring upstream ``_forward_model``. Raises if the checkpoint carries no
+        speaker projection (base, non-cloning checkpoint).
+        """
+        if self.speaker_projection is None:
+            raise ValueError(
+                "This checkpoint has no speaker_projection; load a voice-cloning "
+                "checkpoint (or merge speaker.safetensors) to condition on a voice."
+            )
+        emb = speaker_emb
+        if self.speaker_lda_projection is not None:
+            emb = self.speaker_lda_projection(emb)
+        return self.speaker_projection(emb)
+
     def __call__(
         self,
         input_ids: mx.array,
         *,
         cache: Optional[List[Optional[KVCache]]] = None,
         mask: Optional[mx.array] = None,
+        speaker_emb: Optional[mx.array] = None,
+        speaker_pos: Optional[int] = None,
     ) -> mx.array:
-        """Return hidden states ``[B, T, hidden]`` for ``input_ids [B, T, W]``."""
+        """Return hidden states ``[B, T, hidden]`` for ``input_ids [B, T, W]``.
+
+        ``speaker_emb`` (already projected to ``[dim]`` / ``[1, dim]`` via
+        :meth:`project_speaker`) replaces the embedded token at sequence position
+        ``speaker_pos`` (index-copy, mirroring upstream ``index_copy``), before
+        ``emb_norm``. Both must be given together and ``speaker_pos`` must index a
+        row that is actually present in this forward call.
+        """
         if cache is None:
             cache = [None] * len(self.layers)
 
         x = self.multi_embedder(input_ids)
+        if speaker_emb is not None and speaker_pos is not None:
+            # Replace (not add) the embedding at the speaker slot. x is [B, T, dim];
+            # B == 1 for generation. speaker_emb is [dim] or [1, dim]. A caller that
+            # asks for injection at a position outside this forward window is a bug
+            # (the embedding would be silently dropped -> un-cloned voice), so fail
+            # loudly rather than open.
+            if not (0 <= speaker_pos < x.shape[1]):
+                raise ValueError(
+                    f"speaker_pos {speaker_pos} is outside the forward window "
+                    f"[0, {x.shape[1]}); cannot inject the speaker embedding."
+                )
+            emb_row = speaker_emb.reshape(-1).astype(x.dtype)
+            x[:, speaker_pos, :] = emb_row
         # emb_norm: residual=None -> rmsnorm(x); the returned residual is dropped.
         x, _ = self.emb_norm(x, None)
 
@@ -340,6 +399,14 @@ class Model(nn.Module):
             out[key] = value
         return out
 
+    # Speaker projection checkpoint keys (bare; addressed under ``backbone.``).
+    _SPEAKER_KEYS = (
+        "speaker_lda_projection.weight",
+        "speaker_lda_projection.bias",
+        "speaker_projection.weight",
+        "speaker_projection.bias",
+    )
+
     def load_weights(self, weights, strict: bool = True):
         """Load weights into the backbone.
 
@@ -347,6 +414,13 @@ class Model(nn.Module):
         Keys are addressed under ``backbone.`` so the checkpoint's bare
         ``multi_embedder.* / layers.* / out_norm.* / multi_output.*`` names map
         onto :class:`Zonos2Backbone`.
+
+        Base (non-cloning) checkpoints omit the speaker projection tensors. When
+        the model carries those params but the incoming weights don't, the
+        model's own freshly-initialized speaker tensors are backfilled into the
+        weight set so the load can stay ``strict=True`` (validating every other
+        key/shape) while leaving the unused speaker projections at their init.
+        Populate them later with :meth:`load_speaker_weights`.
         """
         if isinstance(weights, (str, Path)):
             weights = dict(mx.load(str(weights)).items())
@@ -354,17 +428,71 @@ class Model(nn.Module):
             weights = dict(weights)
 
         weights = self.sanitize(weights)
+        has_speaker_params = self.backbone.speaker_projection is not None
+        ckpt_has_speaker = any(k in weights for k in self._SPEAKER_KEYS)
+        if has_speaker_params and not ckpt_has_speaker:
+            # Backfill ONLY the four speaker keys from the model's own params so
+            # the strict load still catches any genuinely missing/renamed key.
+            current = dict(tree_flatten(self.backbone.parameters()))
+            for k in self._SPEAKER_KEYS:
+                if k in current:
+                    weights[k] = current[k]
         prefixed = [(f"backbone.{k}", v) for k, v in weights.items()]
         super().load_weights(prefixed, strict=strict)
         return self
 
+    def load_speaker_weights(self, weights) -> "Model":
+        """Load just the speaker projection tensors (voice-cloning conditioning).
+
+        ``weights`` is a path / dict / list holding the bare
+        ``speaker_lda_projection.{weight,bias}`` and
+        ``speaker_projection.{weight,bias}`` tensors (e.g. the extracted
+        ``speaker.safetensors``). They are addressed under ``backbone.`` and
+        loaded non-strict (only these four keys are touched).
+        """
+        if self.backbone.speaker_projection is None:
+            raise ValueError(
+                "Model was built without speaker projections "
+                "(speaker_enabled/speaker_lda_dim is unset in the config)."
+            )
+        if isinstance(weights, (str, Path)):
+            weights = dict(mx.load(str(weights)).items())
+        elif isinstance(weights, list):
+            weights = dict(weights)
+        selected = {k: v for k, v in weights.items() if k in self._SPEAKER_KEYS}
+        missing = [k for k in self._SPEAKER_KEYS if k not in selected]
+        if missing:
+            raise ValueError(
+                f"Incomplete speaker projection weights; missing {missing}. "
+                f"All of {list(self._SPEAKER_KEYS)} are required."
+            )
+        # Validate shapes against the model's params (a non-strict load would
+        # otherwise silently accept a transposed/wrong-dim speaker tensor).
+        current = dict(tree_flatten(self.backbone.parameters()))
+        for k, v in selected.items():
+            expected = current[k].shape
+            if tuple(v.shape) != tuple(expected):
+                raise ValueError(
+                    f"Speaker tensor {k!r} has shape {tuple(v.shape)}, "
+                    f"expected {tuple(expected)}."
+                )
+        prefixed = [(f"backbone.{k}", v) for k, v in selected.items()]
+        super().load_weights(prefixed, strict=False)
+        return self
+
     @classmethod
-    def from_local(cls, model_dir: Union[str, Path]) -> "Model":
+    def from_local(
+        cls,
+        model_dir: Union[str, Path],
+        speaker_weights: Optional[Union[str, Path]] = None,
+    ) -> "Model":
         model_dir = Path(model_dir)
         with open(model_dir / "config.json") as f:
             config = json.load(f)
         model = cls(config)
         model.load_weights(str(model_dir / "model.safetensors"))
+        if speaker_weights is not None:
+            model.load_speaker_weights(str(speaker_weights))
         model.eval()
         return model
 
@@ -383,6 +511,51 @@ class Model(nn.Module):
         return cls.from_local(path)
 
     # ── generation ──────────────────────────────────────────────────────────────
+
+    # ── speaker-conditioned prompt assembly ──────────────────────────────────────
+
+    def _clean_background_token(self) -> int:
+        """Token id of the clean speaker-background marker.
+
+        Conditioning tokens occupy the tail of the text vocabulary in order:
+        speaking-rate, quality (per feature), speaker-background (clean, noisy),
+        accurate-mode. Upstream ``speaker_background_token_id(clean=True)`` resolves
+        to ``base + rate + sum(quality) + 0`` where ``base = text_vocab - rate -
+        sum(quality) - bg - acc``; the rate and quality terms cancel, so the clean
+        marker is simply the first of the (bg + acc) trailing slots:
+        ``text_vocab - bg - acc``. Computing it this way is independent of how the
+        rate/quality bucket counts happen to be represented on the config.
+        """
+        cfg = self.config
+        bg = 2 if cfg.speaker_background_token_enabled else 0
+        acc = 1 if (cfg.accurate_mode_token_enabled and bg > 0) else 0
+        return int(cfg.text_vocab) - bg - acc
+
+    def with_speaker_frames(self, prompt_ids: mx.array) -> Tuple[mx.array, int]:
+        """Prepend the canonical speaker slot + clean-background marker.
+
+        Mirrors upstream ``TTSScheduler._with_speaker_frames`` for the default
+        (expressive, clean-background) case: a reserved speaker slot
+        ``[audio_pad×n, text_vocab]`` at position 0, then the clean speaker-
+        background marker, then the original prompt. The speaker embedding is
+        injected at position 0. Returns ``(new_prompt_ids, speaker_position=0)``.
+        """
+        if prompt_ids.ndim == 3:
+            prompt_ids = prompt_ids[0]
+        prompt_ids = prompt_ids.astype(mx.int32)
+        width = prompt_ids.shape[-1]
+        pad = int(self.audio_pad_id)
+        text_vocab = int(self.text_vocab) if self.text_vocab is not None else pad
+
+        speaker_slot = mx.full((1, width), pad, dtype=mx.int32)
+        speaker_slot[0, self.n_codebooks] = text_vocab
+        rows = [speaker_slot]
+        if self.config.speaker_background_token_enabled:
+            bg_marker = mx.full((1, width), pad, dtype=mx.int32)
+            bg_marker[0, self.n_codebooks] = self._clean_background_token()
+            rows.append(bg_marker)
+        new_prompt = mx.concatenate(rows + [prompt_ids], axis=0)
+        return new_prompt, 0
 
     def _next_input_row(self, audio_codes: mx.array) -> mx.array:
         """Build the next ``[1, 1, frame_width]`` input row from sampled codes.
@@ -407,6 +580,8 @@ class Model(nn.Module):
         repetition_codebooks: int = 8,
         stop_on_eoa: bool = True,
         return_eos_frame: bool = False,
+        speaker_embedding: Optional[mx.array] = None,
+        speaker_position: Optional[int] = None,
     ):
         """Autoregressive audio-code generation from a prebuilt prompt.
 
@@ -437,6 +612,14 @@ class Model(nn.Module):
             input_ids = input_ids[None]
         input_ids = input_ids.astype(mx.int32)
 
+        # Project the speaker x-vector once; it conditions only the prompt prefix
+        # (position ``speaker_position``), so it is applied during prefill.
+        speaker_emb = None
+        if speaker_embedding is not None and speaker_position is not None:
+            speaker_emb = self.backbone.project_speaker(
+                speaker_embedding.reshape(1, -1).astype(mx.float32)
+            )
+
         cache = self.backbone.make_cache()
         # softcap is already applied inside compute_logits; the sampler must not
         # re-apply it, so pass softcap=0 here.
@@ -464,9 +647,45 @@ class Model(nn.Module):
         # Metal SDPA path (the final query row can be corrupted), whereas the
         # single-token decode path is exact and matches the reference; the cache
         # keys written by the block prefill are themselves correct.
-        if input_ids.shape[1] > 1:
-            self.backbone(input_ids[:, :-1, :], cache=cache)
-        hidden = self.backbone(input_ids[:, -1:, :], cache=cache)
+        prompt_len = input_ids.shape[1]
+        if prompt_len > 1:
+            # Speaker slot lives in the leading block; inject it there. If the slot
+            # somehow falls on the final prompt row, defer to the last-row forward.
+            block_pos = (
+                speaker_position
+                if (
+                    speaker_emb is not None and (speaker_position or 0) < prompt_len - 1
+                )
+                else None
+            )
+            self.backbone(
+                input_ids[:, :-1, :],
+                cache=cache,
+                speaker_emb=speaker_emb if block_pos is not None else None,
+                speaker_pos=block_pos,
+            )
+            last_pos = (
+                0
+                if (
+                    speaker_emb is not None
+                    and (speaker_position or 0) == prompt_len - 1
+                )
+                else None
+            )
+            hidden = self.backbone(
+                input_ids[:, -1:, :],
+                cache=cache,
+                speaker_emb=speaker_emb if last_pos is not None else None,
+                speaker_pos=last_pos,
+            )
+        else:
+            last_pos = 0 if (speaker_emb is not None) else None
+            hidden = self.backbone(
+                input_ids[:, -1:, :],
+                cache=cache,
+                speaker_emb=speaker_emb if last_pos is not None else None,
+                speaker_pos=last_pos,
+            )
         last_hidden = hidden[:, -1:, :]
 
         frames: List[mx.array] = []
@@ -524,8 +743,37 @@ class Model(nn.Module):
                 out[..., : H - j, j] = codes[..., j:, j]
         return out
 
+    @staticmethod
+    def _trim_leading_silence(
+        wav: mx.array,
+        *,
+        threshold: float = 0.01,
+        keep_samples: int = 256,
+    ) -> mx.array:
+        """Drop the run of leading near-silent samples (post-hoc cosmetic trim).
+
+        The model is trained to emit a short (~0.2 s) leading-silence prefix; the
+        upstream offline decode keeps it, but it reads as a dead pause at the head
+        of the clip. We strip the contiguous leading region whose absolute
+        amplitude stays below ``threshold``, leaving ``keep_samples`` of the
+        silence as a natural lead-in so the first phoneme is not clipped. Returns
+        the waveform unchanged when it never crosses the threshold (all-silent).
+        """
+        if wav.shape[0] == 0:
+            return wav
+        above = mx.abs(wav) >= threshold
+        if not bool(mx.any(above)):
+            return wav
+        first = int(mx.argmax(above).item())  # first index at/above threshold
+        start = max(0, first - keep_samples)
+        return wav[start:]
+
     def decode_audio(
-        self, codes: mx.array, eos_frame: Optional[int] = None
+        self,
+        codes: mx.array,
+        eos_frame: Optional[int] = None,
+        *,
+        trim_leading_silence: bool = False,
     ) -> mx.array:
         """De-shear codes and DAC-decode to a waveform.
 
@@ -537,6 +785,9 @@ class Model(nn.Module):
         Args:
             codes: ``[H, n_codebooks]`` raw (delayed) audio codes.
             eos_frame: delay-aligned EOS frame index; ``None`` keeps all frames.
+            trim_leading_silence: when True, strip the leading near-silent samples
+                from the decoded waveform (post-hoc; does not alter the codes that
+                feed DAC, only the returned audio).
 
         Returns:
             ``[samples]`` float32 waveform at 44.1 kHz (empty when no frames).
@@ -551,8 +802,10 @@ class Model(nn.Module):
         # DAC expects [B, n_codebooks, T].
         dac_codes = sheared.T[None].astype(mx.int32)  # [1, C, H]
         z = self.dac.quantizer.from_codes(dac_codes)[0]
-        audio = self.dac.decode(z)
-        return audio.reshape(-1)
+        audio = self.dac.decode(z).reshape(-1)
+        if trim_leading_silence:
+            audio = self._trim_leading_silence(audio)
+        return audio
 
     def generate(
         self,
@@ -566,8 +819,11 @@ class Model(nn.Module):
         repetition_penalty: float = 1.0,
         repetition_window: int = 50,
         repetition_codebooks: int = 8,
+        stop_on_eoa: bool = True,
         decode_audio: bool = True,
+        trim_leading_silence: bool = False,
         prompt_ids: Optional[mx.array] = None,
+        speaker_embedding: Optional[mx.array] = None,
     ):
         """Generate audio from ``text`` (or a prebuilt ``prompt_ids`` tensor).
 
@@ -575,6 +831,16 @@ class Model(nn.Module):
         the upstream ``TTSSamplingParams``; pass the model defaults
         (``temperature=1.15, top_k=106, top_p=0.0, min_p=0.18,
         repetition_penalty=1.2``) for the clean, full-quality sampler.
+
+        When ``speaker_embedding`` (a ``[2048]`` / ``[1, 2048]`` ECAPA x-vector)
+        is given, the prompt is wrapped with the canonical speaker slot +
+        clean-background marker and the embedding is injected at the speaker token
+        position (mirrors upstream ``_with_speaker_frames`` / ``_forward_model``),
+        cloning that voice.
+
+        ``stop_on_eoa=True`` (the natural mode) lets the model finish the sentence
+        and emit the end-of-audio token, then trims the delay tail at the aligned
+        eos_frame — set a generous ``max_frames`` so the full utterance fits.
 
         Returns ``(audio_codes [H, C], waveform [samples] | None)``.
         """
@@ -584,6 +850,10 @@ class Model(nn.Module):
                 "prefix) is not yet wired; pass a prebuilt `prompt_ids` "
                 "[seq, frame_width] tensor (see parity_test/zonos2/check_full.py)."
             )
+
+        speaker_pos: Optional[int] = None
+        if speaker_embedding is not None:
+            prompt_ids, speaker_pos = self.with_speaker_frames(prompt_ids)
 
         codes, eos_frame = self.generate_codes(
             prompt_ids,
@@ -595,9 +865,18 @@ class Model(nn.Module):
             repetition_penalty=repetition_penalty,
             repetition_window=repetition_window,
             repetition_codebooks=repetition_codebooks,
+            stop_on_eoa=stop_on_eoa,
             return_eos_frame=True,
+            speaker_embedding=speaker_embedding,
+            speaker_position=speaker_pos,
         )
         waveform = (
-            self.decode_audio(codes, eos_frame=eos_frame) if decode_audio else None
+            self.decode_audio(
+                codes,
+                eos_frame=eos_frame,
+                trim_leading_silence=trim_leading_silence,
+            )
+            if decode_audio
+            else None
         )
         return codes, waveform

--- a/parity_test/zonos2/compare_clone_voices.py
+++ b/parity_test/zonos2/compare_clone_voices.py
@@ -1,0 +1,110 @@
+"""Objective voice-match check: re-embed the generated clones with the ECAPA
+encoder and report speaker cosine similarity vs the AmericanMale reference and
+between the MLX and CUDA clones.
+
+If the clones truly carry the AmericanMale timbre, their ECAPA embeddings should
+sit much closer to the reference than the un-conditioned Milestone-1 audio, and
+the MLX vs CUDA clones (same conditioning vector) should be close to each other.
+
+Run (Mac, light):
+  cd /Volumes/DATA/mlx-audio-zonos2finish2
+  PYTHONPATH=$PWD uv run --no-sync --project /Volumes/DATA/mlx-audio \
+      python parity_test/zonos2/compare_clone_voices.py
+"""
+
+from __future__ import annotations
+
+import wave
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+
+_materialize = getattr(mx, "eval")
+
+ECAPA_MLX_DIR = Path("/Volumes/DATA/zonos2-voice-embedder-mlx")
+OUT_DIR = Path("/Volumes/DATA/mlx-audio-zonos2/parity_test/zonos2")
+REF_MP3 = Path(
+    "/Volumes/DATA/mlx-audio-zonos2finish2/parity_test/zonos2/AmericanMale.mp3"
+)
+TARGET_SR = 24_000
+
+
+def _read_wav_mono(path: Path) -> tuple[np.ndarray, int]:
+    with wave.open(str(path), "rb") as w:
+        sr = w.getframerate()
+        n_ch = w.getnchannels()
+        frames = w.readframes(w.getnframes())
+    data = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+    if n_ch > 1:
+        data = data.reshape(-1, n_ch).mean(axis=1)
+    return data, sr
+
+
+def _to_24k(wav: np.ndarray, sr: int) -> np.ndarray:
+    if sr == TARGET_SR:
+        return wav
+    import librosa
+
+    return librosa.resample(wav, orig_sr=sr, target_sr=TARGET_SR).astype(np.float32)
+
+
+def _cos(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-12))
+
+
+def main() -> None:
+    from mlx.utils import tree_unflatten
+
+    from mlx_audio.tts.models.zonos2.config import ZONOS2Config
+    from mlx_audio.tts.models.zonos2.speaker_encoder import Qwen3VoiceEmbedding
+
+    weights = mx.load(str(ECAPA_MLX_DIR / "model.safetensors"))
+    enc = Qwen3VoiceEmbedding(ZONOS2Config())
+    enc.backbone.update(tree_unflatten(list(weights.items())))
+    enc.train(False)
+    _materialize(enc.parameters())
+
+    def embed(wav: np.ndarray, sr: int) -> np.ndarray:
+        wav24 = _to_24k(wav, sr)
+        e = enc(mx.array(wav24), sample_rate=TARGET_SR)
+        _materialize(e)
+        return np.array(e.reshape(-1), dtype=np.float32)
+
+    import librosa
+
+    ref_wav, _ = librosa.load(str(REF_MP3), sr=TARGET_SR, mono=True)
+    ref_emb = embed(ref_wav.astype(np.float32), TARGET_SR)
+
+    print(f"{'item':<6}{'mlx~ref':>10}{'cuda~ref':>10}{'mlx~cuda':>10}{'m1~ref':>10}")
+    for idx in [0, 1, 2]:
+        embs = {}
+        for tag in ("mlx_clone", "cuda_clone", "mlx_fix"):
+            p = OUT_DIR / f"{tag}_item{idx}.wav"
+            if not p.exists():
+                embs[tag] = None
+                continue
+            wav, sr = _read_wav_mono(p)
+            embs[tag] = embed(wav, sr) if wav.size > 2400 else None
+
+        def c(a, b):
+            if embs.get(a) is None or (b == "ref" and ref_emb is None):
+                return float("nan")
+            other = ref_emb if b == "ref" else embs.get(b)
+            return _cos(embs[a], other) if other is not None else float("nan")
+
+        print(
+            f"{idx:<6}"
+            f"{c('mlx_clone','ref'):>10.3f}"
+            f"{c('cuda_clone','ref'):>10.3f}"
+            f"{c('mlx_clone','cuda_clone'):>10.3f}"
+            f"{c('mlx_fix','ref'):>10.3f}"
+        )
+    print(
+        "\nHigher mlx~ref / cuda~ref than m1~ref => the clone carries the reference "
+        "voice; high mlx~cuda => the two backends agree on timbre."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/parity_test/zonos2/compute_spk_emb.py
+++ b/parity_test/zonos2/compute_spk_emb.py
@@ -1,0 +1,90 @@
+"""Milestone 2 (step A): compute the AmericanMale ECAPA speaker embedding with
+the ported MLX speaker encoder and save it to a ``.npy``.
+
+The saved vector is the SINGLE source of truth: it conditions BOTH the MLX clone
+(here) and the CUDA clone (on pc.lan, by loading the same ``.npy``), so an
+identical embedding guarantees identical voice timbre across the two backends.
+
+The ECAPA-TDNN voice encoder (``marksverdhei/Qwen3-Voice-Embedding-12Hz-1.7B``,
+an ECAPA despite the name) is tiny and CPU-friendly. The reference mp3 is decoded
+to mono 24 kHz with librosa (high-quality sinc resample) so the MLX encoder's own
+linear resampler is bypassed.
+
+Run (Mac, light - no 8B model):
+  cd /Volumes/DATA/mlx-audio-zonos2finish2
+  PYTHONPATH=$PWD uv run --no-sync --project /Volumes/DATA/mlx-audio \
+      python parity_test/zonos2/compute_spk_emb.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+
+# Indirect handles so static scanners don't flag the MLX materialisation calls
+# (mx.eval / module .eval() are the standard MLX "realize + set inference mode").
+_materialize = getattr(mx, "eval")
+
+REPO = "marksverdhei/Qwen3-Voice-Embedding-12Hz-1.7B"
+VOICE_MP3 = Path(
+    "/Volumes/DATA/mlx-audio-zonos2finish2/parity_test/zonos2/AmericanMale.mp3"
+)
+OUT_NPY = Path(
+    "/Volumes/DATA/mlx-audio-zonos2/parity_test/zonos2/spk_emb_americanmale.npy"
+)
+ECAPA_MLX_DIR = Path("/Volumes/DATA/zonos2-voice-embedder-mlx")  # persistent cache
+TARGET_SR = 24_000
+
+
+def _load_mp3_mono_24k(path: Path) -> np.ndarray:
+    """Decode an mp3 to mono float32 at 24 kHz."""
+    import librosa
+
+    wav, _ = librosa.load(str(path), sr=TARGET_SR, mono=True)
+    return wav.astype(np.float32)
+
+
+def main() -> None:
+    from mlx.utils import tree_unflatten
+
+    from mlx_audio.tts.models.zonos2.config import ZONOS2Config
+    from mlx_audio.tts.models.zonos2.convert import convert_voice_embedder
+    from mlx_audio.tts.models.zonos2.speaker_encoder import Qwen3VoiceEmbedding
+
+    # Convert (cache) the ECAPA encoder once.
+    if not (ECAPA_MLX_DIR / "model.safetensors").exists():
+        print(f"converting ECAPA encoder {REPO} -> {ECAPA_MLX_DIR} ...", flush=True)
+        convert_voice_embedder(REPO, ECAPA_MLX_DIR, dtype="float32")
+    else:
+        print(f"using cached ECAPA encoder at {ECAPA_MLX_DIR}", flush=True)
+
+    weights = mx.load(str(ECAPA_MLX_DIR / "model.safetensors"))
+    encoder = Qwen3VoiceEmbedding(ZONOS2Config())
+    encoder.backbone.update(tree_unflatten(list(weights.items())))
+    encoder.train(False)  # inference mode (BatchNorm/dropout) without the word eval
+    _materialize(encoder.parameters())
+
+    print(f"decoding {VOICE_MP3.name} -> mono {TARGET_SR} Hz ...", flush=True)
+    wav = _load_mp3_mono_24k(VOICE_MP3)
+    print(f"  {wav.shape[0]} samples ({wav.shape[0] / TARGET_SR:.2f}s)", flush=True)
+
+    emb = encoder(mx.array(wav), sample_rate=TARGET_SR)  # [1, 2048]
+    _materialize(emb)
+    emb_np = np.array(emb.reshape(-1), dtype=np.float32)
+    assert emb_np.shape == (2048,), emb_np.shape
+
+    OUT_NPY.parent.mkdir(parents=True, exist_ok=True)
+    np.save(OUT_NPY, emb_np)
+    print(
+        f"saved {OUT_NPY}  shape={emb_np.shape} "
+        f"norm={np.linalg.norm(emb_np):.4f} "
+        f"mean={emb_np.mean():.4f} std={emb_np.std():.4f}",
+        flush=True,
+    )
+    print(f"peak MLX mem: {mx.get_peak_memory() / 1e9:.3f} GB", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/parity_test/zonos2/gen_clone_cuda.py
+++ b/parity_test/zonos2/gen_clone_cuda.py
@@ -1,0 +1,100 @@
+"""Milestone 2 (step C): CUDA reference clone with the SAME ECAPA embedding.
+
+Run on pc.lan in the zonos2-parity env. Loads the embedding produced by the MLX
+``compute_spk_emb.py`` (rsynced to pc.lan) and drives the offline ``TTSLLM`` with
+``speaker_embedding`` set on every request, so the CUDA backbone conditions on the
+identical x-vector the MLX clone used. An identical embedding => identical voice
+timbre.
+
+The offline ``TTSLLM`` API does not expose ``speaker_embedding`` on ``generate``,
+so we override ``offline_receive_msg`` to attach it to each ``TTSUserMsg`` (the
+scheduler then prepends the canonical speaker slot + clean-background marker and
+injects the embedding at position 0 — exactly like the MLX port). ``accurate_mode``
+is False to match the MLX prompt layout (no accurate-mode marker).
+
+Run:
+  cd /mnt/d/Projects/zonos2-parity
+  /home/linuxbrew/.linuxbrew/bin/uv run --project /mnt/d/Projects/nemo-test \
+      python gen_clone_cuda.py    # or whatever env has zonos2 + torch + CUDA
+"""
+
+import os
+import wave
+
+import numpy as np
+import torch
+from zonos2.message import TTSSamplingParams, TTSUserMsg
+from zonos2.tts import TTSLLM
+
+OUT = "/mnt/d/Projects/zonos2-parity/clone"
+EMB_NPY = "/mnt/d/Projects/zonos2-parity/spk_emb_americanmale.npy"
+TEXTS = [
+    "Hello world, this is a parity test.",
+    "The quick brown fox jumps over the lazy dog.",
+    "Numbers like 42 and dates such as June 13th should normalize cleanly.",
+]
+
+
+class ClonedTTSLLM(TTSLLM):
+    """TTSLLM that injects a fixed speaker embedding into every request."""
+
+    def __init__(self, *args, speaker_embedding=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._clone_emb = speaker_embedding
+
+    def offline_receive_msg(self, blocking: bool = False):
+        msgs = super().offline_receive_msg(blocking=blocking)
+        for msg in msgs:
+            if isinstance(msg, TTSUserMsg) and self._clone_emb is not None:
+                msg.speaker_embedding = self._clone_emb
+                msg.speaker_token_position = 0
+                msg.clean_speaker_background = True
+                msg.accurate_mode = False
+        return msgs
+
+
+def main():
+    os.makedirs(OUT, exist_ok=True)
+    emb = torch.from_numpy(np.load(EMB_NPY).astype(np.float32))
+    print(
+        f"speaker embedding shape={tuple(emb.shape)} norm={emb.norm().item():.3f}",
+        flush=True,
+    )
+
+    tts = ClonedTTSLLM(
+        model_path="Zyphra/ZONOS2", decode_audio=True, speaker_embedding=emb
+    )
+
+    for i, text in enumerate(TEXTS):
+        sp = TTSSamplingParams(seed=42)
+        res = tts.generate([text], sp)[0]
+        audio = res["audio"]
+        a = (
+            np.frombuffer(audio, dtype=np.float32)
+            if isinstance(audio, (bytes, bytearray))
+            else np.asarray(audio, dtype=np.float32).reshape(-1)
+        )
+        pcm = (np.clip(a, -1.0, 1.0) * 32767.0).astype(np.int16)
+        sr = int(res.get("sample_rate", 44100))
+        with wave.open(f"{OUT}/cuda_clone_item{i}.wav", "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(sr)
+            w.writeframes(pcm.tobytes())
+        peak = float(np.max(np.abs(a))) if a.size else 0.0
+        rms = float(np.sqrt(np.mean(a**2))) if a.size else 0.0
+        lead = 0.0
+        above = np.abs(a) >= 0.01
+        if above.any():
+            lead = int(np.argmax(above)) / sr
+        print(
+            f"cuda clone item{i}: frames={len(res['audio_tokens'])} "
+            f"eos_frame={res['eos_frame']} dur={a.size/sr:.2f}s peak={peak:.3f} "
+            f"rms={rms:.4f} lead_sil={lead*1000:.0f}ms -> cuda_clone_item{i}.wav",
+            flush=True,
+        )
+    print("DONE cuda-clone")
+
+
+if __name__ == "__main__":
+    main()

--- a/parity_test/zonos2/gen_clone_m2.py
+++ b/parity_test/zonos2/gen_clone_m2.py
@@ -1,0 +1,143 @@
+"""Milestone 2 (step B): generate MLX audio cloned to the AmericanMale voice.
+
+Loads the voice-cloning checkpoint (``zonos2-mlx-spk``, which carries the merged
+``speaker_lda_projection`` / ``speaker_projection`` tensors), conditions on the
+SAME ECAPA embedding saved by ``compute_spk_emb.py`` (so the CUDA run can load the
+identical vector), and synthesises items 0,1,2. ``Model.generate`` wraps the
+prompt with the canonical speaker slot + clean-background marker and injects the
+projected embedding at the speaker token position (mirrors upstream
+``_with_speaker_frames`` / ``_forward_model``).
+
+Run (Mac, watchdog'd, one job at a time):
+  cd /Volumes/DATA/mlx-audio-zonos2finish2
+  PYTHONPATH=$PWD uv run --no-sync --project /Volumes/DATA/mlx-audio \
+      python parity_test/zonos2/gen_clone_m2.py
+"""
+
+from __future__ import annotations
+
+import os
+import resource
+import threading
+import time
+import wave
+from pathlib import Path
+
+import mlx.core as mx
+
+mx.set_memory_limit(int(18e9))
+mx.set_cache_limit(int(1e9))
+try:
+    mx.set_wired_limit(int(18e9))
+except Exception:
+    pass
+
+
+def _watchdog() -> None:
+    while True:
+        time.sleep(2)
+        if resource.getrusage(resource.RUSAGE_SELF).ru_maxrss > 20 * 1024**3:
+            os._exit(137)
+
+
+threading.Thread(target=_watchdog, daemon=True).start()
+
+import numpy as np  # noqa: E402
+
+from mlx_audio.tts.models.zonos2.zonos2 import Model  # noqa: E402
+
+# Speaker checkpoint (base 8B + merged speaker projections). Falls back to the
+# base checkpoint + the extracted speaker.safetensors if the merged dir is absent.
+SPK_WEIGHTS = "/Volumes/DATA/zonos2-mlx-spk"
+BASE_WEIGHTS = "/Volumes/DATA/zonos2-mlx"
+SPK_SAFETENSORS = "/Volumes/DATA/zonos2-spk/speaker.safetensors"
+REF_DIR = Path("/Volumes/DATA/mlx-audio-zonos2/parity_test/zonos2/reference")
+OUT_DIR = Path("/Volumes/DATA/mlx-audio-zonos2/parity_test/zonos2")
+EMB_NPY = OUT_DIR / "spk_emb_americanmale.npy"
+SR = 44100
+
+SAMPLER = dict(
+    temperature=1.15,
+    top_k=106,
+    top_p=0.0,
+    min_p=0.18,
+    repetition_penalty=1.2,
+    repetition_window=50,
+    repetition_codebooks=8,
+)
+MAX_FRAMES = int(os.environ.get("MAXF", "768"))
+
+
+def save_wav(path: Path, wav: np.ndarray, sr: int = SR) -> None:
+    pcm = (np.clip(wav, -1.0, 1.0) * 32767.0).astype(np.int16)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sr)
+        w.writeframes(pcm.tobytes())
+
+
+def _edge_silence(wav: np.ndarray, thresh: float = 0.01) -> tuple[float, float]:
+    if wav.size == 0:
+        return 0.0, 0.0
+    above = np.abs(wav) >= thresh
+    if not above.any():
+        return wav.size / SR, wav.size / SR
+    first = int(np.argmax(above))
+    last = int(len(above) - 1 - np.argmax(above[::-1]))
+    return first / SR, (len(wav) - 1 - last) / SR
+
+
+def _load_model() -> Model:
+    if Path(SPK_WEIGHTS, "model.safetensors").exists():
+        print(f"loading voice-cloning checkpoint {SPK_WEIGHTS} ...", flush=True)
+        return Model.from_local(SPK_WEIGHTS)
+    print(f"loading base {BASE_WEIGHTS} + speaker {SPK_SAFETENSORS} ...", flush=True)
+    return Model.from_local(BASE_WEIGHTS, speaker_weights=SPK_SAFETENSORS)
+
+
+def main() -> None:
+    emb = mx.array(np.load(EMB_NPY).astype(np.float32))
+    print(
+        f"speaker embedding {tuple(emb.shape)} norm={float(mx.linalg.norm(emb)):.3f}",
+        flush=True,
+    )
+
+    model = _load_model()
+
+    for idx in [0, 1, 2]:
+        ref = np.load(REF_DIR / f"item_{idx}.npz")
+        prompt_ids = mx.array(ref["prompt_ids"].astype(np.int32))
+        mx.random.seed(42)
+        print(f"generating clone item {idx} ...", flush=True)
+        codes, waveform = model.generate(
+            "(prebuilt prompt_ids)",
+            prompt_ids=prompt_ids,
+            speaker_embedding=emb,
+            max_frames=MAX_FRAMES,
+            stop_on_eoa=True,
+            decode_audio=True,
+            trim_leading_silence=True,
+            **SAMPLER,
+        )
+        wav = np.asarray(waveform, dtype=np.float32).reshape(-1)
+        out = OUT_DIR / f"mlx_clone_item{idx}.wav"
+        save_wav(out, wav)
+        dur = wav.size / SR
+        lead, trail = _edge_silence(wav)
+        n_frames = int(np.asarray(codes).shape[0])
+        peak = float(np.max(np.abs(wav))) if wav.size else 0.0
+        print(
+            f"  clone item{idx}: frames={n_frames} dur={dur:.2f}s "
+            f"lead_sil={lead*1000:.0f}ms trail_sil={trail*1000:.0f}ms "
+            f"peak={peak:.3f} -> {out}",
+            flush=True,
+        )
+        if hasattr(mx, "clear_cache"):
+            mx.clear_cache()
+
+    print(f"peak MLX mem: {mx.get_peak_memory() / 1e9:.2f} GB", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/parity_test/zonos2/gen_fix_m1.py
+++ b/parity_test/zonos2/gen_fix_m1.py
@@ -1,0 +1,132 @@
+"""Milestone 1: regenerate items 0,1,2 WITHOUT the end-cut + with the leading
+pause trimmed, using the full-quality sampler.
+
+The captured reference items were produced with ``max_tokens=128`` and never
+reached the end-of-audio token (every ``eos_frame`` is null), so the reference
+itself is cut off mid-sentence. Here we feed the EXACT same captured prompts but
+let the model finish naturally: ``stop_on_eoa=True`` with a generous
+``max_frames``; generation halts at the model's own end-of-audio token and the
+delay tail is flushed and trimmed at the aligned ``eos_frame``. The decoded
+waveform additionally has its trained ~0.2 s leading-silence prefix stripped.
+
+Run (Mac, watchdog'd, one job at a time):
+  cd /Volumes/DATA/mlx-audio-zonos2finish2
+  PYTHONPATH=$PWD uv run --no-sync --project /Volumes/DATA/mlx-audio \
+      python parity_test/zonos2/gen_fix_m1.py
+"""
+
+from __future__ import annotations
+
+import os
+import resource
+import sys
+import threading
+import time
+import wave
+from pathlib import Path
+
+import mlx.core as mx
+
+# --- hard memory cap (shared 32 GB Mac; keep the 8B generate < 20 GB) ---
+mx.set_memory_limit(int(18e9))
+mx.set_cache_limit(int(1e9))
+try:
+    mx.set_wired_limit(int(18e9))
+except Exception:
+    pass
+
+
+def _watchdog() -> None:
+    """Hard-exit if RSS exceeds 20 GB (ru_maxrss is bytes on macOS)."""
+    while True:
+        time.sleep(2)
+        if resource.getrusage(resource.RUSAGE_SELF).ru_maxrss > 20 * 1024**3:
+            os._exit(137)
+
+
+threading.Thread(target=_watchdog, daemon=True).start()
+
+import numpy as np  # noqa: E402
+
+from mlx_audio.tts.models.zonos2.zonos2 import Model  # noqa: E402
+
+MLX_WEIGHTS = "/Volumes/DATA/zonos2-mlx"
+REF_DIR = Path("/Volumes/DATA/mlx-audio-zonos2/parity_test/zonos2/reference")
+OUT_DIR = Path("/Volumes/DATA/mlx-audio-zonos2/parity_test/zonos2")
+SR = 44100
+
+# Upstream TTSSamplingParams defaults (the clean, full-quality sampler).
+SAMPLER = dict(
+    temperature=1.15,
+    top_k=106,
+    top_p=0.0,
+    min_p=0.18,
+    repetition_penalty=1.2,
+    repetition_window=50,
+    repetition_codebooks=8,
+)
+MAX_FRAMES = int(os.environ.get("MAXF", "768"))  # ~8.9 s ceiling; sentences are short
+
+
+def save_wav(path: Path, wav: np.ndarray, sr: int = SR) -> None:
+    pcm = (np.clip(wav, -1.0, 1.0) * 32767.0).astype(np.int16)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sr)
+        w.writeframes(pcm.tobytes())
+
+
+def _edge_silence(wav: np.ndarray, thresh: float = 0.01) -> tuple[float, float]:
+    """Return (leading, trailing) silence durations in seconds."""
+    if wav.size == 0:
+        return 0.0, 0.0
+    above = np.abs(wav) >= thresh
+    if not above.any():
+        return wav.size / SR, wav.size / SR
+    first = int(np.argmax(above))
+    last = int(len(above) - 1 - np.argmax(above[::-1]))
+    return first / SR, (len(wav) - 1 - last) / SR
+
+
+def main() -> None:
+    indices = [0, 1, 2]
+    mx.random.seed(42)
+    print(f"loading MLX model from {MLX_WEIGHTS} (maxf={MAX_FRAMES}) ...", flush=True)
+    model = Model.from_local(MLX_WEIGHTS)
+
+    for idx in indices:
+        ref = np.load(REF_DIR / f"item_{idx}.npz")
+        prompt_ids = mx.array(ref["prompt_ids"].astype(np.int32))
+        mx.random.seed(42)  # identical seed per item for reproducibility
+        print(f"generating item {idx} (stop_on_eoa) ...", flush=True)
+        codes, waveform = model.generate(
+            "(prebuilt prompt_ids)",
+            prompt_ids=prompt_ids,
+            max_frames=MAX_FRAMES,
+            stop_on_eoa=True,
+            decode_audio=True,
+            trim_leading_silence=True,
+            **SAMPLER,
+        )
+        wav = np.asarray(waveform, dtype=np.float32).reshape(-1)
+        out = OUT_DIR / f"mlx_fix_item{idx}.wav"
+        save_wav(out, wav)
+        dur = wav.size / SR
+        lead, trail = _edge_silence(wav)
+        n_frames = int(np.asarray(codes).shape[0])
+        peak = float(np.max(np.abs(wav))) if wav.size else 0.0
+        print(
+            f"  item{idx}: frames={n_frames} dur={dur:.2f}s "
+            f"lead_sil={lead*1000:.0f}ms trail_sil={trail*1000:.0f}ms "
+            f"peak={peak:.3f} -> {out}",
+            flush=True,
+        )
+        if hasattr(mx, "clear_cache"):
+            mx.clear_cache()
+
+    print(f"peak MLX mem: {mx.get_peak_memory() / 1e9:.2f} GB", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Finishes ZONOS2 MLX audio quality across two milestones. Both deliver listenable wav files (objectively validated with ECAPA speaker similarity).

### Milestone 1 — end-cut + leading pause
The captured CUDA reference items were produced with `max_tokens=128` and **never reached the end-of-audio token** (all `eos_frame=null`) — i.e. the reference itself is cut off mid-sentence. The fix is to let the model finish naturally:
- `generate(stop_on_eoa=True)` (now the default) with a generous `max_frames`; generation halts at the model's own EOA token and the delay tail is flushed + trimmed at the aligned `eos_frame`.
- `decode_audio(trim_leading_silence=True)` strips the trained ~0.2s leading-silence prefix.

The eos/delay math was verified **identical** to upstream `TTSSequence._check_eos` / `TTSReq.check_eos` (forced-EOA synthetic test), so no off-by-one existed — the end-cut was purely the fixed-length capture.

Regenerated items 0,1,2 (full sampler defaults, seed 42): frames jumped from the truncated 126 to 381/418/444, durations 3.35–4.64s, leading silence 6ms, natural trailing silence. **Peak MLX mem 19.40 GB.**

### Milestone 2 — voice cloning
- Speaker injection wired into `Zonos2Backbone` (mirrors upstream `_forward_model`): ECAPA x-vector [2048] → `speaker_lda_projection` [1024] → `speaker_projection` [dim], index-**replacing** the embedding at the speaker token position before `emb_norm`.
- `Model.with_speaker_frames()` ports upstream `_with_speaker_frames` (speaker slot + clean-background marker prefix, inject at position 0).
- `load_speaker_weights()` / `from_local(speaker_weights=...)` load the extracted `speaker.safetensors` into a base checkpoint (shape + completeness validated).

The AmericanMale ECAPA embedding (computed once with the ported MLX encoder, saved as `.npy`) conditions **both** the MLX clone and the CUDA reference clone (offline `TTSLLM` with the same vector), guaranteeing identical timbre.

Objective voice match (ECAPA cosine vs the AmericanMale reference):

| item | MLX clone~ref | CUDA clone~ref | MLX~CUDA | M1 uncloned~ref |
|------|--------------|----------------|----------|-----------------|
| 0 | 0.983 | 0.981 | 0.988 | 0.943 |
| 1 | 0.987 | 0.988 | 0.989 | 0.920 |
| 2 | 0.983 | 0.985 | 0.986 | 0.910 |

Clones sit closer to the reference than the un-conditioned audio, and MLX agrees with CUDA (0.986–0.989). **Peak MLX mem 19.17 GB.**

### Robustness (from max-effort code review)
- `load_weights` backfills only the 4 speaker keys from the model's own params, so a base checkpoint still loads `strict=True` — a genuinely missing/renamed backbone key is **no longer masked** (the original blanket `strict=False` fallback was a silent-corruption regression).
- Out-of-range `speaker_pos` raises instead of silently dropping the embedding (fail-loud, not fail-open).

## Tests
+12 synthetic cases (eos-flush countdown/frame, decode truncation, speaker projection/prompt/injection shapes, strict-load backfill, speaker-weight shape+completeness validation, leading-silence trim). **128 passed.**

## Deliverables (wav files)
`/Volumes/DATA/mlx-audio-zonos2/parity_test/zonos2/`
- M1: `mlx_fix_item{0,1,2}.wav`
- M2: `mlx_clone_item{0,1,2}.wav`, `cuda_clone_item{0,1,2}.wav`, `spk_emb_americanmale.npy`