### PR TITLE
feat(tts/zonos2): clean quality conditioning (remove background noise)

### DIFF
--- a/mlx_audio/tts/models/zonos2/tests/test_zonos2.py
+++ b/mlx_audio/tts/models/zonos2/tests/test_zonos2.py
@@ -482,6 +482,224 @@ def test_speaker_injection_out_of_range_position_raises():
     assert raised, "out-of-range speaker_pos must raise, not silently no-op"
 
 
+def _quality_config(**ov) -> ZONOS2Config:
+    """Tiny config with speaking-rate + 2 quality features + bg/acc markers.
+
+    Mirrors the real conditioning-token tail layout so the prompt-builder token
+    math can be checked against hand-derived ids.
+    """
+    return _tiny_config(
+        text_vocab=40,
+        speaker_background_token_enabled=True,
+        accurate_mode_token_enabled=True,
+        speaking_rate_num_buckets=2,
+        quality_features=("lufs", "snr"),
+        quality_buckets={"lufs": ("a", "b", "c"), "snr": ("d", "e")},
+        **ov,
+    )
+
+
+def test_conditioning_base_and_token_ids():
+    """base/clean-bg/rate/quality ids match the upstream tail arithmetic."""
+    cfg = _quality_config()
+    model = Model(cfg)
+    rate, bg, acc = 2, 2, 1
+    counts = [3, 2]  # lufs, snr
+    base = cfg.text_vocab - rate - sum(counts) - bg - acc
+    assert model._conditioning_base_text_vocab() == base
+    # clean-bg marker = text_vocab - bg - acc (first of the trailing markers).
+    assert model._clean_background_token() == cfg.text_vocab - bg - acc
+    # speaking-rate bucket b -> base + b.
+    assert model._speaking_rate_token(0) == base
+    assert model._speaking_rate_token(1) == base + 1
+    # quality: base + rate + sum(counts[:feature]) + bucket.
+    assert model._quality_token(0, 0) == base + rate + 0  # lufs[0]
+    assert model._quality_token(0, 2) == base + rate + 2  # lufs[2]
+    assert model._quality_token(1, 0) == base + rate + 3  # snr[0] (after 3 lufs)
+    assert model._quality_token(1, 1) == base + rate + 4  # snr[1]
+
+
+def test_resolve_quality_buckets_dict_list_and_default():
+    cfg = _quality_config()
+    model = Model(cfg)
+    # dict -> feature order; missing feature -> None.
+    assert model._resolve_quality_buckets({"snr": 1}) == [None, 1]
+    assert model._resolve_quality_buckets({"lufs": 2, "snr": 0}) == [2, 0]
+    # list -> truncated to feature count.
+    assert model._resolve_quality_buckets([1, 0, 9]) == [1, 0]
+    # None -> the default conditioning (trailing_silence_s only -> all None here,
+    # since this tiny config has no trailing_silence_s feature).
+    assert model._resolve_quality_buckets(None) == [None, None]
+    # empty dict -> disable (all None).
+    assert model._resolve_quality_buckets({}) == [None, None]
+    # model without quality conditioning -> None regardless.
+    plain = Model(_tiny_config())
+    assert plain._resolve_quality_buckets({"x": 1}) is None
+
+
+def test_shear_down_applies_delay_pattern():
+    # Independent ground truth (not via shear_up): column j shifted DOWN by j rows;
+    # vacated head filled with pad. Mirrors upstream ``shear``.
+    pad = 99
+    codes = mx.array(
+        [
+            [10, 11, 12],
+            [20, 21, 22],
+            [30, 31, 32],
+        ],
+        dtype=mx.int32,
+    )
+    out = np.asarray(Model._shear_down(codes, pad))
+    expected = np.array(
+        [
+            [10, pad, pad],
+            [20, 11, pad],
+            [30, 21, 12],
+        ],
+        dtype=np.int64,
+    )
+    assert np.array_equal(out, expected)
+
+
+def test_shear_down_is_inverse_of_shear_up():
+    pad = 99
+    base = mx.array(np.random.randint(0, 50, (7, 9)).astype(np.int32))
+    down = Model._shear_down(base, pad)
+    up = Model.shear_up(down, pad)
+    # shear_up(shear_down(x)) == x for every cell that was not pushed out the tail.
+    n = np.asarray(base)
+    r = np.asarray(up)
+    for t in range(n.shape[0]):
+        for c in range(n.shape[1]):
+            if t + c < n.shape[0]:  # cell survives the round trip
+                assert int(r[t, c]) == int(n[t, c])
+
+
+def test_build_prompt_ids_row_structure():
+    cfg = _quality_config()
+    model = Model(cfg)
+    text = "hi"
+    # No silence, explicit quality + speaking rate so every row is deterministic.
+    prompt = model.build_prompt_ids(
+        text,
+        quality_buckets={"lufs": 1, "snr": 0},
+        speaking_rate_bucket=1,
+        normalize=False,
+        prepend_silence=False,
+    )
+    np_p = np.asarray(prompt)
+    pad = cfg.audio_pad_id
+    # All audio columns are the audio pad id (text-only prompt rows).
+    assert np.all(np_p[:, : cfg.n_codebooks] == pad)
+    text_col = np_p[:, cfg.n_codebooks].tolist()
+    enc = model.tokenizer.encode(text)  # BOS + bytes + EOS
+    expected = [
+        model._speaking_rate_token(1),
+        model._quality_token(0, 1),
+        model._quality_token(1, 0),
+        *enc,
+    ]
+    assert text_col == expected
+    assert np_p.shape == (len(expected), cfg.n_codebooks + 1)
+
+
+def _reference_silence_suffix(cfg: ZONOS2Config) -> np.ndarray:
+    """Independent ground truth for ``_silence_suffix`` (no shear helper reuse).
+
+    Down-shears the verbatim ``_SILENCE_TOKENS_0_2S`` constant by hand
+    (``out[t, c] = silence[t - c, c]`` for ``t >= c`` else ``audio_pad_id``) and
+    appends the text-pad column, mirroring upstream ``silence_prompt_tokens``.
+    """
+    from mlx_audio.tts.models.zonos2.zonos2 import _SILENCE_TOKENS_0_2S
+
+    silence = np.array(_SILENCE_TOKENS_0_2S, dtype=np.int64)[:, : cfg.n_codebooks]
+    rows, cols = silence.shape
+    out = np.full((rows, cols), cfg.audio_pad_id, dtype=np.int64)
+    for t in range(rows):
+        for c in range(cols):
+            if t - c >= 0:
+                out[t, c] = silence[t - c, c]
+    text_col = np.full((rows, 1), cfg.text_vocab, dtype=np.int64)
+    return np.concatenate([out, text_col], axis=1)
+
+
+def test_build_prompt_ids_appends_silence_suffix():
+    cfg = _quality_config()
+    model = Model(cfg)
+    with_sil = np.asarray(
+        model.build_prompt_ids("hi", quality_buckets={}, normalize=False)
+    )
+    without = np.asarray(
+        model.build_prompt_ids(
+            "hi", quality_buckets={}, normalize=False, prepend_silence=False
+        )
+    )
+    # 17 silence frames appended (the trained 0.2 s prefix).
+    assert with_sil.shape[0] == without.shape[0] + 17
+    suffix = np.asarray(model._silence_suffix()).astype(np.int64)
+    assert suffix.shape == (17, cfg.n_codebooks + 1)
+    # Silence suffix text column is the text-pad id everywhere.
+    assert np.all(suffix[:, cfg.n_codebooks] == cfg.text_vocab)
+    # Verify the SHEARED VALUES against an independent hand-computed reference
+    # (not against _silence_suffix itself) so a wrong shear direction is caught.
+    assert np.array_equal(suffix, _reference_silence_suffix(cfg))
+    assert np.array_equal(with_sil[-17:], suffix)
+
+
+def test_build_prompt_ids_default_quality_only_trailing_silence():
+    """The default conditioning sets only trailing_silence_s (matches upstream)."""
+    cfg = _tiny_config(
+        text_vocab=40,
+        speaker_background_token_enabled=True,
+        accurate_mode_token_enabled=True,
+        speaking_rate_num_buckets=2,
+        quality_features=("lufs", "trailing_silence_s"),
+        quality_buckets={
+            "lufs": ("a", "b"),
+            "trailing_silence_s": ("p", "q", "r", "s"),
+        },
+    )
+    model = Model(cfg)
+    resolved = model._resolve_quality_buckets(None)
+    # DEFAULT_QUALITY_BUCKETS == {"trailing_silence_s": 3}.
+    assert resolved == [None, 3]
+    prompt = np.asarray(
+        model.build_prompt_ids("x", normalize=False, prepend_silence=False)
+    )
+    enc = model.tokenizer.encode("x")
+    # One quality row (trailing_silence_s bucket 3) then the text rows.
+    assert prompt[:, cfg.n_codebooks].tolist() == [model._quality_token(1, 3), *enc]
+
+
+def test_generate_from_text_builds_prompt_and_runs():
+    """``generate(text=...)`` now builds the prompt itself (no NotImplementedError).
+
+    Uses the full ``text_vocab=519`` so the byte rows (``byte + 192`` -> ids up to
+    447) index a real text-embedding table; a tiny ``text_vocab`` would push those
+    ids out of bounds and MLX ``nn.Embedding`` reads garbage instead of raising,
+    making the smoke test pass vacuously.
+    """
+    cfg = _tiny_config(
+        text_vocab=519,
+        speaker_background_token_enabled=True,
+        accurate_mode_token_enabled=True,
+        speaking_rate_num_buckets=2,
+        quality_features=("lufs", "snr"),
+        quality_buckets={"lufs": ("a", "b", "c"), "snr": ("d", "e")},
+    )
+    model = Model(cfg)
+    codes, _ = model.generate(
+        "hello",
+        quality_buckets={},
+        max_frames=3,
+        temperature=0.0,
+        top_k=1,
+        decode_audio=False,
+    )
+    assert codes.shape == (3, cfg.n_codebooks)
+    assert codes.dtype == mx.int32
+
+
 def test_load_weights_reconciles_convert_keys():
     """A synthetic checkpoint in convert.py's key layout loads strictly."""
     cfg = _tiny_config()

--- a/mlx_audio/tts/models/zonos2/zonos2.py
+++ b/mlx_audio/tts/models/zonos2/zonos2.py
@@ -52,6 +52,35 @@ from mlx_audio.tts.models.zonos2.moe import MoEFeedForward
 from mlx_audio.tts.models.zonos2.sampling import make_codebook_sampler
 from mlx_audio.tts.models.zonos2.tokenizer import ZONOS2Tokenizer
 
+# Default quality conditioning applied by the upstream offline TTS / server when
+# no explicit ``quality_buckets`` is given: it only sets a trailing-silence bucket
+# and leaves SNR / loudness / bandwidth unconditioned, which is why the default
+# voice carries background noise. Mirrors ``tts/llm.py DEFAULT_QUALITY_BUCKETS``.
+DEFAULT_QUALITY_BUCKETS = {"trailing_silence_s": 3}
+
+# Pre-computed 0.2 s silence frames (17 frames x 9 codebooks) appended after the
+# text prompt before audio generation begins. Verbatim from upstream
+# ``tts/prompt.py _SILENCE_TOKENS_0_2S`` (the trained prompt format).
+_SILENCE_TOKENS_0_2S = [
+    [568, 778, 338, 524, 967, 360, 728, 550, 90],
+    [568, 778, 10, 674, 364, 981, 741, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 804, 10, 674, 364, 981, 568, 378, 731],
+    [568, 778, 721, 842, 264, 974, 989, 507, 308],
+]
+
 
 class RMSNormFused(nn.Module):
     """Fused add-norm RMSNorm mirroring upstream ``RMSNormFused``.
@@ -512,24 +541,194 @@ class Model(nn.Module):
 
     # ── generation ──────────────────────────────────────────────────────────────
 
-    # ── speaker-conditioned prompt assembly ──────────────────────────────────────
+    # ── conditioning / prompt assembly ───────────────────────────────────────────
+
+    def _quality_bucket_counts(self) -> List[int]:
+        """Per-feature quality bucket counts in the model's feature order.
+
+        Mirrors ``self.quality_bucket_counts`` in upstream ``tts/llm.py``: the
+        number of buckets for each feature in ``config.quality_features``, read off
+        the ``config.quality_buckets`` boundary lists. Empty when the model defines
+        no quality conditioning.
+        """
+        cfg = self.config
+        buckets = cfg.quality_buckets or {}
+        return [len(buckets.get(feature, ())) for feature in cfg.quality_features]
+
+    def _conditioning_counts(self) -> Tuple[int, int, int, List[int]]:
+        """Return ``(speaking_rate_num_buckets, bg, acc, quality_counts)``.
+
+        ``bg`` / ``acc`` are the speaker-background (clean+noisy) and accurate-mode
+        marker counts that occupy the very tail of the text vocab (accurate-mode is
+        only present when speaker-background is). Single source of truth for every
+        conditioning-token offset.
+        """
+        cfg = self.config
+        rate = int(cfg.speaking_rate_num_buckets)
+        bg = 2 if cfg.speaker_background_token_enabled else 0
+        acc = 1 if (cfg.accurate_mode_token_enabled and bg > 0) else 0
+        return rate, bg, acc, self._quality_bucket_counts()
+
+    def _conditioning_base_text_vocab(self) -> int:
+        """First conditioning-token id (``base``) in the text vocabulary tail.
+
+        Conditioning tokens occupy the tail of the text vocab in order:
+        speaking-rate, quality (per feature), speaker-background (clean, noisy),
+        accurate-mode. ``base = text_vocab - rate - sum(quality) - bg - acc`` is the
+        id of the first speaking-rate slot; every other conditioning id is an offset
+        from it. Mirrors upstream ``_conditioning_base_text_vocab``.
+        """
+        rate, bg, acc, counts = self._conditioning_counts()
+        return int(self.text_vocab) - rate - sum(counts) - bg - acc
 
     def _clean_background_token(self) -> int:
         """Token id of the clean speaker-background marker.
 
-        Conditioning tokens occupy the tail of the text vocabulary in order:
-        speaking-rate, quality (per feature), speaker-background (clean, noisy),
-        accurate-mode. Upstream ``speaker_background_token_id(clean=True)`` resolves
-        to ``base + rate + sum(quality) + 0`` where ``base = text_vocab - rate -
-        sum(quality) - bg - acc``; the rate and quality terms cancel, so the clean
-        marker is simply the first of the (bg + acc) trailing slots:
-        ``text_vocab - bg - acc``. Computing it this way is independent of how the
-        rate/quality bucket counts happen to be represented on the config.
+        ``speaker_background_token_id(clean=True) = base + rate + sum(quality) + 0``;
+        the rate/quality terms cancel against ``base`` so the clean marker is simply
+        the first of the (bg + acc) trailing slots: ``text_vocab - bg - acc``.
         """
-        cfg = self.config
-        bg = 2 if cfg.speaker_background_token_enabled else 0
-        acc = 1 if (cfg.accurate_mode_token_enabled and bg > 0) else 0
-        return int(cfg.text_vocab) - bg - acc
+        _, bg, acc, _ = self._conditioning_counts()
+        return int(self.text_vocab) - bg - acc
+
+    def _speaking_rate_token(self, bucket: int) -> int:
+        """Token id for speaking-rate ``bucket`` (``base + bucket``)."""
+        rate, _, _, _ = self._conditioning_counts()
+        if rate <= 0:
+            raise ValueError("Model does not define speaking-rate buckets.")
+        if not 0 <= int(bucket) < rate:
+            raise ValueError(
+                f"speaking_rate_bucket must be in [0, {rate - 1}], got {bucket}."
+            )
+        return self._conditioning_base_text_vocab() + int(bucket)
+
+    def _quality_token(self, feature_idx: int, bucket: int) -> int:
+        """Token id for quality ``feature_idx`` at ``bucket``.
+
+        ``base + rate + sum(counts[:feature]) + bucket`` (mirrors upstream
+        ``quality_token_id``); the quality block follows the speaking-rate block.
+        """
+        rate, _, _, counts = self._conditioning_counts()
+        if not counts:
+            raise ValueError("Model does not define quality buckets.")
+        f = int(feature_idx)
+        if not 0 <= f < len(counts):
+            raise ValueError(
+                f"quality feature index must be in [0, {len(counts) - 1}], got {f}."
+            )
+        if not 0 <= int(bucket) < counts[f]:
+            raise ValueError(
+                f"quality bucket for feature {f} must be in "
+                f"[0, {counts[f] - 1}], got {bucket}."
+            )
+        return (
+            self._conditioning_base_text_vocab() + rate + sum(counts[:f]) + int(bucket)
+        )
+
+    def _resolve_quality_buckets(
+        self, quality_buckets
+    ) -> Optional[List[Optional[int]]]:
+        """Map a quality-bucket dict/list onto the model's feature order.
+
+        Mirrors upstream ``TTSLLM._resolve_quality_buckets``:
+
+        * model with no quality conditioning -> ``None``;
+        * ``quality_buckets is None`` -> the default conditioning
+          (:data:`DEFAULT_QUALITY_BUCKETS`, same as the server);
+        * ``dict`` -> ``[buckets.get(feature) for feature in quality_features]``;
+        * ``list`` -> truncated to the number of features.
+
+        Pass an empty dict/list to disable quality tokens entirely.
+        """
+        counts = self._quality_bucket_counts()
+        if not counts or sum(counts) == 0:
+            return None
+        if quality_buckets is None:
+            quality_buckets = DEFAULT_QUALITY_BUCKETS
+        features = self.config.quality_features
+        if isinstance(quality_buckets, dict):
+            return [quality_buckets.get(feature) for feature in features]
+        return list(quality_buckets)[: len(features)]
+
+    def _text_row(self, text_token: int) -> List[int]:
+        """A single text-prompt row: ``[audio_pad × n_codebooks, text_token]``."""
+        return [int(self.audio_pad_id)] * self.n_codebooks + [int(text_token)]
+
+    def _silence_suffix(self) -> mx.array:
+        """The trained 0.2 s silence suffix as ``[17, frame_width]`` int32 ids.
+
+        Applies the delay pattern (down-shear) to :data:`_SILENCE_TOKENS_0_2S` and
+        appends the text-pad column, mirroring upstream ``silence_prompt_tokens``.
+        """
+        silence = mx.array(_SILENCE_TOKENS_0_2S, dtype=mx.int32)[:, : self.n_codebooks]
+        sheared = self._shear_down(silence, int(self.audio_pad_id))
+        text_col = mx.full((sheared.shape[0], 1), int(self.text_vocab), dtype=mx.int32)
+        return mx.concatenate([sheared, text_col], axis=1)
+
+    @staticmethod
+    def _shear_down(codes: mx.array, pad_id: int) -> mx.array:
+        """Apply the delay pattern: column ``j`` shifted DOWN by ``j`` rows.
+
+        Inverse of :meth:`shear_up`. ``codes`` is ``[T, C]``; output ``[T, C]`` with
+        ``out[t, j] = codes[t - j, j]`` for ``t >= j`` and ``pad_id`` otherwise.
+        Mirrors upstream ``tts/prompt.py shear``.
+        """
+        T, C = codes.shape[-2], codes.shape[-1]
+        out = mx.full(codes.shape, pad_id, dtype=codes.dtype)
+        for j in range(C):
+            if T > j:
+                out[..., j:, j] = codes[..., : T - j, j]
+        return out
+
+    def build_prompt_ids(
+        self,
+        text: str,
+        *,
+        quality_buckets=None,
+        speaking_rate_bucket: Optional[int] = None,
+        normalize: bool = True,
+        prepend_silence: bool = True,
+    ) -> mx.array:
+        """Build the ``[seq, frame_width]`` text prompt (MLX text->prompt builder).
+
+        Mirrors upstream ``TTSPromptBuilder.build`` / ``_text_rows``. Row order is:
+
+        1. optional speaking-rate conditioning row,
+        2. one quality conditioning row per resolved (non-``None``) feature,
+        3. the text byte rows (``BOS`` + UTF-8 bytes + ``EOS``),
+        4. (when ``prepend_silence``) the trained 0.2 s silence suffix.
+
+        ``quality_buckets`` accepts a feature-keyed dict, a feature-ordered list, or
+        ``None`` for the default (noisy) conditioning; pass ``{}`` to disable quality
+        tokens. Pass the clean buckets (high SNR / good loudness / full bandwidth /
+        minimal silence) to remove the default background noise.
+
+        ``prepend_silence`` names the upstream ``TTSPromptConfig.prepend_silence`` flag
+        (the silence precedes the *generated* audio); the frames are concatenated
+        after the text rows, exactly like upstream ``build``.
+
+        ``normalize`` runs the (optional) NeMo text normalization before byte-encoding.
+        The byte ids therefore depend on whether ``nemo_text_processing`` is installed:
+        for parity against a captured prompt, the capture and this call must agree on
+        the normalization state (the upstream capture normalizes, so the default here
+        is ``True``).
+        """
+        if normalize:
+            text = self.tokenizer.normalize(text)
+        rows: List[List[int]] = []
+        if speaking_rate_bucket is not None:
+            rows.append(self._text_row(self._speaking_rate_token(speaking_rate_bucket)))
+        resolved = self._resolve_quality_buckets(quality_buckets)
+        if resolved is not None:
+            for feature_idx, bucket in enumerate(resolved):
+                if bucket is None:
+                    continue
+                rows.append(self._text_row(self._quality_token(feature_idx, bucket)))
+        rows.extend(self._text_row(tok) for tok in self.tokenizer.encode(text))
+        prompt = mx.array(rows, dtype=mx.int32)
+        if prepend_silence:
+            prompt = mx.concatenate([prompt, self._silence_suffix()], axis=0)
+        return prompt
 
     def with_speaker_frames(self, prompt_ids: mx.array) -> Tuple[mx.array, int]:
         """Prepend the canonical speaker slot + clean-background marker.
@@ -824,6 +1023,9 @@ class Model(nn.Module):
         trim_leading_silence: bool = False,
         prompt_ids: Optional[mx.array] = None,
         speaker_embedding: Optional[mx.array] = None,
+        quality_buckets=None,
+        speaking_rate_bucket: Optional[int] = None,
+        normalize_text: bool = True,
     ):
         """Generate audio from ``text`` (or a prebuilt ``prompt_ids`` tensor).
 
@@ -831,6 +1033,11 @@ class Model(nn.Module):
         the upstream ``TTSSamplingParams``; pass the model defaults
         (``temperature=1.15, top_k=106, top_p=0.0, min_p=0.18,
         repetition_penalty=1.2``) for the clean, full-quality sampler.
+
+        When ``prompt_ids`` is ``None`` the prompt is built from ``text`` via
+        :meth:`build_prompt_ids` using ``quality_buckets`` (feature-keyed dict /
+        feature-ordered list / ``None`` for the default noisy conditioning; pass the
+        clean buckets to drop the background noise) and ``speaking_rate_bucket``.
 
         When ``speaker_embedding`` (a ``[2048]`` / ``[1, 2048]`` ECAPA x-vector)
         is given, the prompt is wrapped with the canonical speaker slot +
@@ -845,10 +1052,11 @@ class Model(nn.Module):
         Returns ``(audio_codes [H, C], waveform [samples] | None)``.
         """
         if prompt_ids is None:
-            raise NotImplementedError(
-                "Text-to-prompt conditioning (speaker/quality buckets, silence "
-                "prefix) is not yet wired; pass a prebuilt `prompt_ids` "
-                "[seq, frame_width] tensor (see parity_test/zonos2/check_full.py)."
+            prompt_ids = self.build_prompt_ids(
+                text,
+                quality_buckets=quality_buckets,
+                speaking_rate_bucket=speaking_rate_bucket,
+                normalize=normalize_text,
             )
 
         speaker_pos: Optional[int] = None

--- a/parity_test/zonos2/08_capture_clean.py
+++ b/parity_test/zonos2/08_capture_clean.py
@@ -1,0 +1,154 @@
+"""STEP A (plain half): capture CLEAN-conditioned prompts + clean CUDA audio.
+
+Run on pc.lan (CUDA, zonos2 env). Writes, for each text:
+  - clean_prompt_item{i}.npy : the EXACT input token tensor _tokenize_one(text,
+    quality_buckets=CLEAN_QB) produces (carries the clean quality conditioning).
+  - default_prompt_item{i}.npy : the default (noisy) prompt, for diffing.
+  - cuda_clean_item{i}.wav : clean plain CUDA audio (seed 42, CLEAN_QB).
+Plus clean_conditioning.json with the model conditioning config so the MLX side can
+reproduce the token math byte-for-byte.
+
+The clean VOICE-CLONE capture lives in 09_capture_clean_clone.py and MUST run as a
+SEPARATE process: the offline engine's TP/distributed info is a process-global
+singleton, so a second TTSLLM in the same process raises "TP info has been set".
+"""
+
+import json
+import os
+import wave
+
+import numpy as np
+from zonos2.message import TTSSamplingParams
+from zonos2.tts import TTSLLM
+from zonos2.tts.llm import DEFAULT_QUALITY_BUCKETS
+
+OUT = "/mnt/d/Projects/zonos2-parity/clean"
+os.makedirs(OUT, exist_ok=True)
+
+TEXTS = [
+    "Hello world, this is a parity test.",
+    "The quick brown fox jumps over the lazy dog.",
+    "Numbers like 42 and dates such as June 13th should normalize cleanly.",
+]
+# CLEAN quality buckets (indices). lufs=7 (-23..-18.5) avoids the lufs=8 clipping.
+CLEAN_QB = {
+    "lufs": 7,
+    "estimated_snr": 11,
+    "max_pause": 0,
+    "estimated_bandlimit_hz": 7,
+    "leading_silence_s": 0,
+    "trailing_silence_s": 0,
+}
+
+
+def to_f32(audio):
+    if isinstance(audio, (bytes, bytearray)):
+        return np.frombuffer(audio, dtype=np.float32).reshape(-1)
+    return np.asarray(audio, dtype=np.float32).reshape(-1)
+
+
+def stat(audio, sr):
+    a = to_f32(audio)
+    win = int(0.02 * sr)
+    floor = 0.0
+    if len(a) >= win:
+        e = np.array(
+            [np.sqrt(np.mean(a[i : i + win] ** 2)) for i in range(0, len(a) - win, win)]
+        )
+        floor = float(np.percentile(e, 10))
+    peak = float(np.max(np.abs(a))) if a.size else 0.0
+    rms = float(np.sqrt(np.mean(a**2))) if a.size else 0.0
+    above = np.abs(a) >= 0.01
+    lead = trail = (a.size / sr) if a.size else 0.0
+    if above.any():
+        first = int(np.argmax(above))
+        last = int(len(above) - 1 - np.argmax(above[::-1]))
+        lead = first / sr
+        trail = (len(a) - 1 - last) / sr
+    return dict(
+        dur=a.size / sr, peak=peak, rms=rms, floor=floor, lead=lead, trail=trail
+    )
+
+
+def save_wav(path, audio, sr):
+    a = to_f32(audio)
+    pcm = (np.clip(a, -1, 1) * 32767).astype(np.int16)
+    with wave.open(path, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(int(sr))
+        w.writeframes(pcm.tobytes())
+
+
+def main():
+    # ---- plain TTS (also used for prompt capture) ----
+    tts = TTSLLM(model_path="Zyphra/ZONOS2", decode_audio=True)
+    from zonos2.tts.prompt import _SILENCE_TOKENS_0_2S
+
+    cond = dict(
+        n_codebooks=int(tts.n_codebooks),
+        audio_pad_id=int(tts.audio_pad_id),
+        text_vocab=int(tts.text_vocab),
+        speaking_rate_num_buckets=int(tts.speaking_rate_num_buckets),
+        quality_features=list(tts.quality_features),
+        quality_bucket_counts=[int(c) for c in tts.quality_bucket_counts],
+        speaker_background_num_buckets=int(tts.speaker_background_num_buckets),
+        accurate_mode_num_buckets=int(tts.accurate_mode_num_buckets),
+        default_quality_buckets=dict(DEFAULT_QUALITY_BUCKETS),
+        clean_quality_buckets=dict(CLEAN_QB),
+        resolved_clean=tts._resolve_quality_buckets(CLEAN_QB),
+        resolved_default=tts._resolve_quality_buckets(None),
+        silence_tokens_0_2s=_SILENCE_TOKENS_0_2S,
+    )
+    with open(os.path.join(OUT, "clean_conditioning.json"), "w") as f:
+        json.dump(cond, f, indent=2)
+    print("COND:", json.dumps(cond), flush=True)
+
+    for i, text in enumerate(TEXTS):
+        pe = (
+            tts._tokenize_one(text, quality_buckets=CLEAN_QB)
+            .cpu()
+            .numpy()
+            .astype(np.int32)
+        )
+        pd = tts._tokenize_one(text).cpu().numpy().astype(np.int32)
+        np.save(os.path.join(OUT, "clean_prompt_item%d.npy" % i), pe)
+        np.save(os.path.join(OUT, "default_prompt_item%d.npy" % i), pd)
+        head = pe[:10, -1].tolist()
+        print(
+            "PROMPT item%d: clean=%s default=%s clean_textcol_head=%s"
+            % (i, pe.shape, pd.shape, head),
+            flush=True,
+        )
+        r = tts.generate([text], TTSSamplingParams(seed=42), quality_buckets=CLEAN_QB)[
+            0
+        ]
+        sr = int(r.get("sample_rate", 44100))
+        save_wav(os.path.join(OUT, "cuda_clean_item%d.wav" % i), r["audio"], sr)
+        s = stat(r["audio"], sr)
+        nf = len(r.get("audio_tokens", []))
+        ef = r.get("eos_frame")
+        print(
+            "CUDA-CLEAN item%d: frames=%d eos=%s dur=%.2fs peak=%.3f rms=%.4f "
+            "floor=%.5f lead=%.0fms trail=%.0fms"
+            % (
+                i,
+                nf,
+                ef,
+                s["dur"],
+                s["peak"],
+                s["rms"],
+                s["floor"],
+                s["lead"] * 1000,
+                s["trail"] * 1000,
+            ),
+            flush=True,
+        )
+    print(
+        "DONE capture-clean (plain); run 09_capture_clean_clone.py for the clone",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/parity_test/zonos2/09_capture_clean_clone.py
+++ b/parity_test/zonos2/09_capture_clean_clone.py
@@ -1,0 +1,129 @@
+"""STEP A (clone half): clean CUDA voice-clone audio (run as its OWN process).
+
+The TP/distributed info is a process-global singleton in the offline engine, so a
+second TTSLLM in the same process raises "TP info has been set". This script
+therefore generates ONLY the clean voice-clone wavs (AmericanMale ECAPA embedding +
+CLEAN_QB) in a fresh process. The plain clean capture lives in 08_capture_clean.py.
+"""
+
+import os
+import wave
+
+import numpy as np
+import torch
+from zonos2.message import TTSSamplingParams, TTSUserMsg
+from zonos2.tts import TTSLLM
+
+OUT = "/mnt/d/Projects/zonos2-parity/clean"
+EMB_NPY = "/mnt/d/Projects/zonos2-parity/spk_emb_americanmale.npy"
+os.makedirs(OUT, exist_ok=True)
+
+TEXTS = [
+    "Hello world, this is a parity test.",
+    "The quick brown fox jumps over the lazy dog.",
+    "Numbers like 42 and dates such as June 13th should normalize cleanly.",
+]
+CLEAN_QB = {
+    "lufs": 7,
+    "estimated_snr": 11,
+    "max_pause": 0,
+    "estimated_bandlimit_hz": 7,
+    "leading_silence_s": 0,
+    "trailing_silence_s": 0,
+}
+
+
+class ClonedTTSLLM(TTSLLM):
+    def __init__(self, *a, speaker_embedding=None, **k):
+        super().__init__(*a, **k)
+        self._clone_emb = speaker_embedding
+
+    def offline_receive_msg(self, blocking=False):
+        msgs = super().offline_receive_msg(blocking=blocking)
+        for m in msgs:
+            if isinstance(m, TTSUserMsg) and self._clone_emb is not None:
+                m.speaker_embedding = self._clone_emb
+                m.speaker_token_position = 0
+                m.clean_speaker_background = True
+                m.accurate_mode = False
+        return msgs
+
+
+def to_f32(audio):
+    if isinstance(audio, (bytes, bytearray)):
+        return np.frombuffer(audio, dtype=np.float32).reshape(-1)
+    return np.asarray(audio, dtype=np.float32).reshape(-1)
+
+
+def stat(audio, sr):
+    a = to_f32(audio)
+    win = int(0.02 * sr)
+    floor = 0.0
+    if len(a) >= win:
+        e = np.array(
+            [np.sqrt(np.mean(a[i : i + win] ** 2)) for i in range(0, len(a) - win, win)]
+        )
+        floor = float(np.percentile(e, 10))
+    peak = float(np.max(np.abs(a))) if a.size else 0.0
+    rms = float(np.sqrt(np.mean(a**2))) if a.size else 0.0
+    above = np.abs(a) >= 0.01
+    lead = trail = (a.size / sr) if a.size else 0.0
+    if above.any():
+        first = int(np.argmax(above))
+        last = int(len(above) - 1 - np.argmax(above[::-1]))
+        lead = first / sr
+        trail = (len(a) - 1 - last) / sr
+    return dict(
+        dur=a.size / sr, peak=peak, rms=rms, floor=floor, lead=lead, trail=trail
+    )
+
+
+def save_wav(path, audio, sr):
+    a = to_f32(audio)
+    pcm = (np.clip(a, -1, 1) * 32767).astype(np.int16)
+    with wave.open(path, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(int(sr))
+        w.writeframes(pcm.tobytes())
+
+
+def main():
+    emb = torch.from_numpy(np.load(EMB_NPY).astype(np.float32))
+    print(
+        "clone embedding shape=%s norm=%.3f" % (tuple(emb.shape), emb.norm().item()),
+        flush=True,
+    )
+    ctts = ClonedTTSLLM(
+        model_path="Zyphra/ZONOS2", decode_audio=True, speaker_embedding=emb
+    )
+    for i, text in enumerate(TEXTS):
+        r = ctts.generate([text], TTSSamplingParams(seed=42), quality_buckets=CLEAN_QB)[
+            0
+        ]
+        sr = int(r.get("sample_rate", 44100))
+        save_wav(os.path.join(OUT, "cuda_clean_clone_item%d.wav" % i), r["audio"], sr)
+        s = stat(r["audio"], sr)
+        nf = len(r.get("audio_tokens", []))
+        ef = r.get("eos_frame")
+        print(
+            "CUDA-CLEAN-CLONE item%d: frames=%d eos=%s dur=%.2fs peak=%.3f rms=%.4f "
+            "floor=%.5f lead=%.0fms trail=%.0fms"
+            % (
+                i,
+                nf,
+                ef,
+                s["dur"],
+                s["peak"],
+                s["rms"],
+                s["floor"],
+                s["lead"] * 1000,
+                s["trail"] * 1000,
+            ),
+            flush=True,
+        )
+    print("DONE capture-clean-clone", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/parity_test/zonos2/gen_clean_m2.py
+++ b/parity_test/zonos2/gen_clean_m2.py
@@ -1,0 +1,238 @@
+"""STEP B + C: clean MLX audio (plain + voice-clone) from the captured clean prompt.
+
+Two things, one watchdog'd 8B load:
+
+  STEP B — feed the CUDA-captured CLEAN-conditioned prompt (``clean_prompt_item{i}.npy``,
+  which carries the high-SNR / good-loudness / full-bandwidth quality tokens) to the
+  MLX backbone:
+    * plain        -> ``mlx_clean_item{i}.wav``
+    * voice-clone  -> ``mlx_clean_clone_item{i}.wav`` (AmericanMale ECAPA x-vector
+      injected at the canonical speaker slot; the clean prompt carries the quality
+      conditioning, the embedding carries the voice).
+
+  STEP C — verify the MLX text->prompt builder is self-sufficient: build
+  ``Model.build_prompt_ids(text, quality_buckets=CLEAN_QB)`` and assert it matches the
+  captured ``clean_prompt_item{i}.npy`` BYTE-FOR-BYTE. If it matches, MLX text->speech
+  needs no CUDA capture.
+
+Run (Mac, one job at a time, hard 20 GB RSS watchdog):
+  cd <worktree>
+  PYTHONPATH=$PWD uv run --no-sync --project /Volumes/DATA/mlx-audio \
+      python parity_test/zonos2/gen_clean_m2.py
+"""
+
+from __future__ import annotations
+
+import os
+import resource
+import threading
+import time
+import wave
+from pathlib import Path
+
+import mlx.core as mx
+
+# --- hard memory cap (<= 20 GB shared Mac); the 8B clean gen peaks ~19 GB. ---
+mx.set_memory_limit(int(18e9))
+mx.set_cache_limit(int(1e9))
+try:
+    mx.set_wired_limit(int(18e9))
+except Exception:
+    pass
+
+
+def _watchdog() -> None:
+    while True:
+        time.sleep(2)
+        if resource.getrusage(resource.RUSAGE_SELF).ru_maxrss > 20 * 1024**3:
+            os._exit(137)
+
+
+threading.Thread(target=_watchdog, daemon=True).start()
+
+import numpy as np  # noqa: E402
+
+from mlx_audio.tts.models.zonos2.zonos2 import Model  # noqa: E402
+
+SPK_WEIGHTS = "/Volumes/DATA/zonos2-mlx-spk"
+BASE_WEIGHTS = "/Volumes/DATA/zonos2-mlx"
+SPK_SAFETENSORS = "/Volumes/DATA/zonos2-spk/speaker.safetensors"
+COORD = Path("/Volumes/DATA/mlx-audio-zonos2/parity_test/zonos2")
+CLEAN_DIR = COORD / "clean"
+EMB_NPY = COORD / "spk_emb_americanmale.npy"
+SR = 44100
+
+# Texts + the clean buckets MUST match 08_capture_clean.py (the CUDA capture).
+TEXTS = [
+    "Hello world, this is a parity test.",
+    "The quick brown fox jumps over the lazy dog.",
+    "Numbers like 42 and dates such as June 13th should normalize cleanly.",
+]
+CLEAN_QB = {
+    "lufs": 7,
+    "estimated_snr": 11,
+    "max_pause": 0,
+    "estimated_bandlimit_hz": 7,
+    "leading_silence_s": 0,
+    "trailing_silence_s": 0,
+}
+
+SAMPLER = dict(
+    temperature=1.15,
+    top_k=106,
+    top_p=0.0,
+    min_p=0.18,
+    repetition_penalty=1.2,
+    repetition_window=50,
+    repetition_codebooks=8,
+)
+MAX_FRAMES = int(os.environ.get("MAXF", "768"))
+
+
+def save_wav(path: Path, wav: np.ndarray, sr: int = SR) -> None:
+    pcm = (np.clip(wav, -1.0, 1.0) * 32767.0).astype(np.int16)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sr)
+        w.writeframes(pcm.tobytes())
+
+
+def edge_silence(wav: np.ndarray, thresh: float = 0.01) -> tuple[float, float]:
+    if wav.size == 0:
+        return 0.0, 0.0
+    above = np.abs(wav) >= thresh
+    if not above.any():
+        return wav.size / SR, wav.size / SR
+    first = int(np.argmax(above))
+    last = int(len(above) - 1 - np.argmax(above[::-1]))
+    return first / SR, (len(wav) - 1 - last) / SR
+
+
+def stats(wav: np.ndarray) -> str:
+    peak = float(np.max(np.abs(wav))) if wav.size else 0.0
+    rms = float(np.sqrt(np.mean(wav**2))) if wav.size else 0.0
+    lead, trail = edge_silence(wav)
+    return (
+        f"dur={wav.size / SR:.2f}s peak={peak:.3f} rms={rms:.4f} "
+        f"lead_sil={lead * 1000:.0f}ms trail_sil={trail * 1000:.0f}ms"
+    )
+
+
+def load_model() -> Model:
+    if Path(SPK_WEIGHTS, "model.safetensors").exists():
+        print(f"loading voice-cloning checkpoint {SPK_WEIGHTS} ...", flush=True)
+        return Model.from_local(SPK_WEIGHTS)
+    print(f"loading base {BASE_WEIGHTS} + speaker {SPK_SAFETENSORS} ...", flush=True)
+    return Model.from_local(BASE_WEIGHTS, speaker_weights=SPK_SAFETENSORS)
+
+
+def verify_step_c(model: Model) -> None:
+    """STEP C: MLX-built clean prompt must match the captured CUDA prompt exactly."""
+    print("\n=== STEP C: MLX build_prompt_ids vs captured CUDA clean prompt ===")
+    all_ok = True
+    for i, text in enumerate(TEXTS):
+        cap_path = CLEAN_DIR / f"clean_prompt_item{i}.npy"
+        if not cap_path.exists():
+            print(f"  item{i}: SKIP (no captured prompt at {cap_path})", flush=True)
+            all_ok = False
+            continue
+        captured = np.load(cap_path).astype(np.int32)
+        built = np.asarray(
+            model.build_prompt_ids(text, quality_buckets=CLEAN_QB)
+        ).astype(np.int32)
+        match = built.shape == captured.shape and np.array_equal(built, captured)
+        all_ok = all_ok and match
+        tag = "MATCH" if match else "MISMATCH"
+        print(
+            f"  item{i}: {tag} built={built.shape} captured={captured.shape}",
+            flush=True,
+        )
+        if not match:
+            n = min(built.shape[0], captured.shape[0])
+            diffs = [
+                (r, int(built[r, -1]), int(captured[r, -1]))
+                for r in range(n)
+                if not np.array_equal(built[r], captured[r])
+            ][:8]
+            print(
+                f"    first text-col diffs (row, built, captured): {diffs}", flush=True
+            )
+    print(
+        "STEP C RESULT: "
+        + ("SELF-SUFFICIENT (MLX text->prompt matches CUDA)" if all_ok else "MISMATCH"),
+        flush=True,
+    )
+
+
+def main() -> None:
+    emb = mx.array(np.load(EMB_NPY).astype(np.float32))
+    print(
+        f"speaker embedding {tuple(emb.shape)} norm={float(mx.linalg.norm(emb)):.3f}",
+        flush=True,
+    )
+
+    model = load_model()
+
+    # STEP C first (cheap; no generation) so we know whether MLX is self-sufficient.
+    verify_step_c(model)
+
+    # STEP B: plain clean from the captured clean prompt.
+    print("\n=== STEP B: plain clean MLX audio ===", flush=True)
+    for i in range(len(TEXTS)):
+        prompt = mx.array(
+            np.load(CLEAN_DIR / f"clean_prompt_item{i}.npy").astype(np.int32)
+        )
+        mx.random.seed(42)
+        codes, waveform = model.generate(
+            "(prebuilt clean prompt)",
+            prompt_ids=prompt,
+            max_frames=MAX_FRAMES,
+            stop_on_eoa=True,
+            decode_audio=True,
+            trim_leading_silence=True,
+            **SAMPLER,
+        )
+        wav = np.asarray(waveform, dtype=np.float32).reshape(-1)
+        out = COORD / f"mlx_clean_item{i}.wav"
+        save_wav(out, wav)
+        n_frames = int(np.asarray(codes).shape[0])
+        print(
+            f"  mlx_clean item{i}: frames={n_frames} {stats(wav)} -> {out}", flush=True
+        )
+        if hasattr(mx, "clear_cache"):
+            mx.clear_cache()
+
+    # STEP B: voice-clone clean (clean prompt + AmericanMale embedding).
+    print("\n=== STEP B: voice-clone clean MLX audio ===", flush=True)
+    for i in range(len(TEXTS)):
+        prompt = mx.array(
+            np.load(CLEAN_DIR / f"clean_prompt_item{i}.npy").astype(np.int32)
+        )
+        mx.random.seed(42)
+        codes, waveform = model.generate(
+            "(prebuilt clean prompt)",
+            prompt_ids=prompt,
+            speaker_embedding=emb,
+            max_frames=MAX_FRAMES,
+            stop_on_eoa=True,
+            decode_audio=True,
+            trim_leading_silence=True,
+            **SAMPLER,
+        )
+        wav = np.asarray(waveform, dtype=np.float32).reshape(-1)
+        out = COORD / f"mlx_clean_clone_item{i}.wav"
+        save_wav(out, wav)
+        n_frames = int(np.asarray(codes).shape[0])
+        print(
+            f"  mlx_clean_clone item{i}: frames={n_frames} {stats(wav)} -> {out}",
+            flush=True,
+        )
+        if hasattr(mx, "clear_cache"):
+            mx.clear_cache()
+
+    print(f"\npeak MLX mem: {mx.get_peak_memory() / 1e9:.2f} GB", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

The default ZONOS2 conditioning is `DEFAULT_QUALITY_BUCKETS = {"trailing_silence_s": 3}` — it only sets a trailing-silence bucket and leaves **SNR / loudness / bandwidth unconditioned**, so the model emits audio with background noise (the "bad mic" sound). Confirmed on CUDA: explicit clean quality buckets produce clean audio.

## Fix

Wire the upstream text->prompt builder into the MLX port and request **clean** quality conditioning (high SNR, good loudness, full bandwidth, minimal silence).

- `Model.build_prompt_ids(text, quality_buckets, speaking_rate_bucket)` mirrors upstream `tts/prompt.py` (`_text_rows` + `build`): speaking-rate row → one quality row per resolved feature → text byte rows → trained 0.2 s silence suffix.
- Conditioning token-id helpers with a single source of truth (`_conditioning_base_text_vocab` / `_conditioning_counts`, `_speaking_rate_token`, `_quality_token`, `_resolve_quality_buckets`) + `_shear_down` (delay pattern, inverse of `shear_up`) for the silence suffix.
- `generate(text=...)` now builds the prompt itself (was `NotImplementedError`); adds `quality_buckets` / `speaking_rate_bucket` / `normalize_text` params. `_clean_background_token` refactored onto the shared base helper (value unchanged).

`CLEAN_QB = {"lufs": 7, "estimated_snr": 11, "max_pause": 0, "estimated_bandlimit_hz": 7, "leading_silence_s": 0, "trailing_silence_s": 0}` — `lufs=7` (−23..−18.5); `lufs=8` clipped at peak≈0.999.

## Verification

**STEP C (self-sufficiency):** MLX `build_prompt_ids(text, CLEAN_QB)` matches the upstream `_tokenize_one(text, quality_buckets=CLEAN_QB)` prompt **byte-for-byte** for all 3 texts (shapes 60/69/94 × 10). MLX text→speech needs no CUDA capture.

**Audio (all CLEAN + NO CLIP, peak < 0.98, low noise floor, clean ends):**

| group | item0 | item1 | item2 |
|---|---|---|---|
| `mlx_clean` (plain) | peak 0.963 | 0.964 | 0.611 |
| `mlx_clean_clone` (voice clone) | 0.395 | 0.429 | 0.576 |
| `cuda_clean` (plain A/B) | 0.797 | 0.736 | 0.554 |
| `cuda_clean_clone` (voice clone A/B) | 0.384 | 0.335 | 0.182 |

0 clipped samples across all 12 wavs; noise floor < 0.009 everywhere. Peak MLX RSS during generation: **18.67 GB** (under the 20 GB cap).

## Tests

Added unit tests: prompt row structure, conditioning token-id math, resolve dict/list/default, `_shear_down` delay pattern + round-trip, silence suffix vs an **independent** hand-computed reference, and `generate(text=...)` on a real `text_vocab`. Full zonos2 suite: 136 passed. Black 24.2.0 + isort 5.13.2 clean.

## Parity scripts (`parity_test/zonos2/`)

- `08_capture_clean.py` — CUDA clean prompts + plain clean wavs (run on the CUDA box).
- `09_capture_clean_clone.py` — CUDA clean voice-clone (separate process: the offline engine's TP info is a process-global singleton).
- `gen_clean_m2.py` — MLX clean plain + voice-clone + the byte-for-byte STEP C check (watchdog'd, 20 GB RSS cap).